### PR TITLE
Added system theme as default theme on page load

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -31,6 +31,10 @@ module.exports = {
     locales: ['en', 'ru', 'de', 'fr', 'es', 'it', 'ja', 'ko', 'zh-CN', 'zh-TW'],
   },
   themeConfig: {
+    colorMode: {
+      defaultMode: 'light',
+      respectPrefersColorScheme: true,
+    },
     docs: {
       sidebar: {
         hideable: true,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "docusaurus start --host 0.0.0.0",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "yarn crowdin:sync && docusaurus deploy",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start --host 0.0.0.0",
+    "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "yarn crowdin:sync && docusaurus deploy",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -175,3 +175,11 @@ html[lang='ko'] .navbar__search {
   background-repeat: no-repeat;
   background-image: url("data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiBoZWlnaHQ9IjE2IiB2aWV3Qm94PSIwIDAgMTcgMTYiIHdpZHRoPSIxNyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZyBzdHJva2U9IiMzYzgxZjYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSIwLjUiPjxwYXRoIGQ9Im0xMi41IDcuODg4Njd2LTMuODg4ODloLTMuODA5NTIiLz48cGF0aCBkPSJtMTIuNDQ3MyA0LjAyNjE3LTQuNTI2MDUgNC42MjAzMSIvPjxwYXRoIGQ9Im02LjM0NDQ4IDQuNjY2OTljLTEuMDE4NjggMC0xLjg0NDQ4LjgyNTgtMS44NDQ0OCAxLjg0NDQ4djMuNDg4ODNjMCAxLjEwNDYuODk1NDMgMiAyIDJoMy41MzA4Yy45OTU1IDAgMS44MDI1LS44MDcgMS44MDI1LTEuODAyNSIvPjwvZz48L3N2Zz4=");
 }
+
+@media (prefers-color-scheme: light) {
+  /* ... */
+}
+
+@media (prefers-color-scheme: dark) {
+  /* ... */
+}


### PR DESCRIPTION
**Refer** [141](https://github.com/AdguardTeam/KnowledgeBase/pull/141)

> Existing behavior on the [AdguardDNS Knowledge Base page](https://adguard-dns.io/kb/) sets the theme to _Light Theme_ by default and does not adapt to the system-wide theme of the host OS.

The changes would set the docusaurus theme to the system theme as default theme right from the first page-load.

@sc0rp10 