### PR TITLE
Update BebasDNS Data

### DIFF
--- a/docs/general/dns-providers.md
+++ b/docs/general/dns-providers.md
@@ -77,7 +77,7 @@ Each of these servers provides a secure and reliable connection, but unlike the 
 
 ### BebasDNS by BebasID
 
-[BebasDNS](https://github.com/bebasid/bebasid) is a free and neutral public resolver based in Indonesia. We have no-logs policy and support DNSSEC along with OpenNIC TLD. We support both port 53 and 1753 for Plain DNS.
+[BebasDNS](https://github.com/bebasid/bebasdns) is a free and neutral public resolver based in Indonesia which supports OpenNIC domain. Created by Komunitas Internet Netral Indonesia (KINI) to serve Indonesian user with free and neutral internet connection.
 
 #### Default
 
@@ -85,11 +85,8 @@ This is the default variant of BebasDNS. This variant blocks ads, malware, and p
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `103.87.68.194` and `35.219.67.150` | [Add to AdGuard](adguard:add_dns_server?address=103.87.68.194&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=103.87.68.194&name=) |
-| DNS, IPv6      | `2a05:dfc7:bca0:beba:51d::53` | [Add to AdGuard](adguard:add_dns_server?address=2a05:dfc7:bca0:beba:51d::53&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a05:dfc7:bca0:beba:51d::53&name=)  |
 | DNS-over-HTTPS | `https://dns.bebasid.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.bebasid.com/dns-query&name=dns.bebasid.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.bebasid.com/dns-query&name=dns.bebasid.com) |
 | DNS-over-TLS   | `tls://dns.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=dns.bebasid.com:853&name=dns.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=dns.bebasid.com:853&name=dns.bebasid.com:853) |
-| DNS-over-QUIC  | `quic://quic.dns.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=quic://quic.dns.bebasid.com:853&name=quic://quic.dns.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=quic://quic.dns.bebasid.com:853&name=quic://quic.dns.bebasid.com:853) |
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.dns.bebasid.com` IP: `103.87.68.194:8443` | [Add to AdGuard](sdns://AQMAAAAAAAAAEjEwMy44Ny42OC4xOTQ6ODQ0MyAxXDKkdrOao8ZeLyu7vTnVrT0C7YlPNNf6trdMkje7QR8yLmRuc2NyeXB0LWNlcnQuZG5zLmJlYmFzaWQuY29t) |
 
 #### Unfiltered
@@ -98,12 +95,8 @@ This variant doesn't filter anything.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `103.87.68.193` | [Add to AdGuard](adguard:add_dns_server?address=103.87.68.193&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=103.87.68.193&name=) |
-| DNS, IPv6      | `2a05:dfc7:bca0:d01c::2` | [Add to AdGuard](adguard:add_dns_server?address=2a05:dfc7:bca0:d01c::2&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a05:dfc7:bca0:d01c::2&name=)  |
 | DNS-over-HTTPS | `https://dns.bebasid.com/unfiltered` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.bebasid.com/unfiltered&name=dns.bebasid.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.bebasid.com/unfiltered&name=dns.bebasid.com) |
 | DNS-over-TLS   | `tls://unfiltered.dns.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=unfiltered.dns.bebasid.com:853&name=unfiltered.dns.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=unfiltered.dns.bebasid.com:853&name=unfiltered.dns.bebasid.com:853) |
-| DNS-over-QUIC  | `quic://unfiltered.dns.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=quic://unfiltered.dns.bebasid.com:853&name=quic://unfiltered.dns.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=quic://unfiltered.dns.bebasid.com:853&name=quic://unfiltered.dns.bebasid.com:853) |
-| DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.unfiltered.dns.bebasid.com` IP: `35.219.67.150:5443` | [Add to AdGuard](sdns://AQcAAAAAAAAAEjM1LjIxOS42Ny4xNTA6NTQ0MyAtDC9I4194j3U0lZcEBPPd43IvR8gGNOS5QNVIx_7PNyoyLmRuc2NyeXB0LWNlcnQudW5maWx0ZXJlZC5kbnMuYmViYXNpZC5jb20) |
 
 #### Security
 
@@ -111,12 +104,8 @@ This is the security/antivirus variant of BebasDNS. This variant only blocks mal
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `103.87.68.195` | [Add to AdGuard](adguard:add_dns_server?address=103.87.68.195&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=103.87.68.195&name=) |
-| DNS, IPv6      | `2a05:dfc7:bca0:beba:51d::5353` | [Add to AdGuard](adguard:add_dns_server?address=2a05:dfc7:bca0:beba:51d::5353&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a05:dfc7:bca0:beba:51d::5353&name=)  |
 | DNS-over-HTTPS | `https://antivirus.bebasid.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://antivirus.bebasid.com/dns-query&name=antivirus.bebasid.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://antivirus.bebasid.com/dns-query&name=antivirus.bebasid.com) |
 | DNS-over-TLS   | `tls://antivirus.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=antivirus.bebasid.com:853&name=antivirus.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=antivirus.bebasid.com:853&name=antivirus.bebasid.com:853) |
-| DNS-over-QUIC  | `quic://quic-antivirus.dns.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=quic://quic-antivirus.dns.bebasid.com:853&name=quic://quic-antivirus.dns.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=quic://quic-antivirus.dns.bebasid.com:853&name=quic://quic-antivirus.dns.bebasid.com:853) |
-| DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.antivirus.bebasid.com` IP: `103.87.68.195:8443` | [Add to AdGuard](sdns://AQMAAAAAAAAAEjEwMy44Ny42OC4xOTU6ODQ0MyDxbZzPMadetG2FodrzRfoiJjJi3cxbOsvKAvMyJ09rfiUyLmRuc2NyeXB0LWNlcnQuYW50aXZpcnVzLmJlYmFzaWQuY29t) |
 
 #### Family
 
@@ -124,12 +113,37 @@ This is the family variant of BebasDNS. This variant blocks pornography, gamblin
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `103.87.68.196` | [Add to AdGuard](adguard:add_dns_server?address=103.87.68.196&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=103.87.68.196&name=) |
-| DNS, IPv6      | `2a05:dfc7:bca0:b00b:beba::51d` | [Add to AdGuard](adguard:add_dns_server?address=2a05:dfc7:bca0:b00b:beba::51d&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a05:dfc7:bca0:b00b:beba::51d&name=)  |
 | DNS-over-HTTPS | `https://internetsehat.bebasid.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://internetsehat.bebasid.com/dns-query&name=internetsehat.bebasid.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://internetsehat.bebasid.com/dns-query&name=internetsehat.bebasid.com) |
 | DNS-over-TLS   | `tls://internetsehat.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=internetsehat.bebasid.com:853&name=internetsehat.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=internetsehat.bebasid.com:853&name=internetsehat.bebasid.com:853) |
-| DNS-over-QUIC  | `quic://quic-sehat.dns.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=quic://quic-sehat.dns.bebasid.com:853&name=quic://quic-sehat.dns.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=quic://quic-sehat.dns.bebasid.com:853&name=quic://quic-sehat.dns.bebasid.com:853) |
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.internetsehat.bebasid.com` IP: `103.87.68.196:8443` | [Add to AdGuard](sdns://AQMAAAAAAAAAEjEwMy44Ny42OC4xOTY6ODQ0MyD5k4vgIHmBCZ2DeLtmoDVu1C6nVrRNzSVgZ1T0m0-3rCkyLmRuc2NyeXB0LWNlcnQuaW50ZXJuZXRzZWhhdC5iZWJhc2lkLmNvbQ) |
+
+#### Family With Ad Filtering
+
+This is the family variant of BebasDNS but with adblocker
+
+| Protocol       | Address                                            |                |
+|----------------|----------------------------------------------------|----------------|
+| DNS-over-HTTPS | `https://internetsehat.bebasid.com/adblock` | [Add to AdGuard](adguard:add_dns_server?address=https://internetsehat.bebasid.com/adblock&name=internetsehat.bebasid.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://internetsehat.bebasid.com/adblock&name=internetsehat.bebasid.com) |
+| DNS-over-TLS   | `tls://family-adblock.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=family-adblock.bebasid.com:853&name=family-adblock.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=family-adblock.bebasid.com:853&name=family-adblock.bebasid.com:853) |
+
+#### OISD Filter
+
+This is a custom BebasDNS variant with only OISD Big filter
+
+| Protocol       | Address                                            |                |
+|----------------|----------------------------------------------------|----------------|
+| DNS-over-HTTPS | `https://dns.bebasid.com/dns-oisd` | [Add to AdGuard](adguard:add_dns_server?address=https://internetsehat.bebasid.com/adblock&name=internetsehat.bebasid.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://internetsehat.bebasid.com/adblock&name=internetsehat.bebasid.com) |
+| DNS-over-TLS   | `tls://oisd.dns.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=oisd.dns.bebasid.com:853&name=oisd.dns.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=oisd.dns.bebasid.com:853&name=oisd.dns.bebasid.com:853) |
+
+#### Hagezi Multi Normal Filter
+
+This is a custom BebasDNS variant with only Hagezi Multi Normal filter
+
+| Protocol       | Address                                            |                |
+|----------------|----------------------------------------------------|----------------|
+| DNS-over-HTTPS | `https://dns.bebasid.com/dns-hagezi` | [Add to AdGuard](adguard:add_dns_server?address=https://internetsehat.bebasid.com/adblock&name=internetsehat.bebasid.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://internetsehat.bebasid.com/adblock&name=internetsehat.bebasid.com) |
+| DNS-over-TLS   | `tls://hagezi.dns.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=hagezi.dns.bebasid.com:853&name=hagezi.dns.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=hagezi.dns.bebasid.com:853&name=hagezi.dns.bebasid.com:853) |
+
 
 ### CFIEC Public DNS
 


### PR DESCRIPTION
Good morning, I want to update the data for BebasDNS

1. BebasDNS started to limit plain DNS to mitigate with DNS amplification attack and most of BebasDNS user connected through DoH/DoT so their team is disabling plain DNS except for whitelisted ISPs.
2. Added Custom Filtering server and the new Family DNS with Adblocker
3. DNS-over-QUIC server is temporary disabled 

You can check their [Github page](https://github.com/bebasid/bebasdns) for more information