### PR TITLE
Update various DNS providers

### DIFF
--- a/docs/general/dns-providers.md
+++ b/docs/general/dns-providers.md
@@ -264,7 +264,7 @@ Blocks phishing, spam and malicious domains.
 | DNS, IPv6      | `2606:4700:4700::1111` and `2606:4700:4700::1001`  | [Add to AdGuard](adguard:add_dns_server?address=2606:4700:4700::1111&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2606:4700:4700::1111&name=) |
 | DNS-over-HTTPS, IPv4 | `https://dns.cloudflare.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.cloudflare.com/dns-query&name=dns.cloudflare.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.cloudflare.com/dns-query&name=dns.cloudflare.com) |
 | DNS-over-HTTPS, IPv6 | `https://dns.cloudflare.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.cloudflare.com:53/dns-query&name=dns.cloudflare.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.cloudflare.com:53/dns-query&name=dns.cloudflare.com) |
-| DNS-over-TLS | `tls://one.one.one.one` | [Add to AdGuard](adguard:add_dns_server?address=tls://one.one.one.on&name=one.one.one.on), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://one.one.one.on&name=one.one.one.on) |
+| DNS-over-TLS | `tls://one.one.one.one` | [Add to AdGuard](adguard:add_dns_server?address=tls://one.one.one.one&name=CloudflareDoT), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://one.one.one.one&name=CloudflareDoT) |
 
 #### Malware blocking only
 
@@ -454,8 +454,8 @@ Hurricane Electric Public Recursor is a free alternative DNS service by Hurrican
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS-over-HTTPS | `https://dns.mullvad.net/dns-query`          | [Add to AdGuard](adguard:add_dns_server?address=https://dns.mullvad.net/dns-query&name=dns.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.mullvad.net/dns-query&name=dns.mullvad.net) |
-| DNS-over-TLS   | `tls://dns.mullvad.net`           | [Add to AdGuard](adguard:add_dns_server?address=tls://dns.mullvad.net&name=dns.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dns.mullvad.net&name=dns.mullvad.net) |
+| DNS-over-HTTPS | `https://dns.mullvad.net/dns-query`          | [Add to AdGuard](adguard:add_dns_server?address=https://dns.mullvad.net/dns-query&name=MullvadDoH), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.mullvad.net/dns-query&name=MullvadDoH) |
+| DNS-over-TLS   | `tls://dns.mullvad.net`           | [Add to AdGuard](adguard:add_dns_server?address=tls://dns.mullvad.net&name=MullvadDoT), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dns.mullvad.net&name=MullvadDoT) |
 
 #### Ad blocking
 

--- a/docs/general/dns-providers.md
+++ b/docs/general/dns-providers.md
@@ -387,7 +387,7 @@ These servers use some logging, self-signed certs or no support for strict mode.
 | DNS, IPv4      | `185.222.222.222` and `45.11.45.11`                | [Add to AdGuard](adguard:add_dns_server?address=185.222.222.222&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=185.222.222.222&name=) |
 | DNS, IPv6      | `2a09::` and `2a11::`                              | [Add to AdGuard](adguard:add_dns_server?address=2a09::&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a09::&name=) |
 | DNS-over-HTTPS | `https://doh.dns.sb/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://doh.dns.sb/dns-query&name=doh.dns.sb), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh.dns.sb/dns-query&name=doh.dns.sb) |
-| DNS-over-TLS | `tls://185.222.222.222` | [Add to AdGuard](adguard:add_dns_server?address=tls://185.222.222.222&name=185.222.222.222), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://185.222.222.222&name=185.222.222.222) |
+| DNS-over-TLS | `tls://dot.sb` | [Add to AdGuard](adguard:add_dns_server?address=tls://dot.sb&name=dot.sb), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dot.sb&name=dot.sb) |
 
 ### DNSPod Public DNS+
 

--- a/docs/general/dns-providers.md
+++ b/docs/general/dns-providers.md
@@ -448,7 +448,7 @@ Hurricane Electric Public Recursor is a free alternative DNS service by Hurrican
 
 ### Mullvad
 
-[Mullvad](https://mullvad.net/en/help/dns-over-https-and-dns-over-tls/) provides publicly accessible DNS with QNAME minimization, endpoints located in Australia, Germany, Singapore, Sweden, United Kingdom and United States (New York and Los Angeles).
+[Mullvad](https://mullvad.net/en/help/dns-over-https-and-dns-over-tls/) provides publicly accessible DNS with QNAME minimization, endpoints located in Germany, Singapore, Sweden, United Kingdom and United States (Dallas & New York).
 
 #### Non-filtering
 

--- a/docs/general/dns-providers.md
+++ b/docs/general/dns-providers.md
@@ -454,15 +454,15 @@ Hurricane Electric Public Recursor is a free alternative DNS service by Hurrican
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS-over-HTTPS | `https://doh.mullvad.net/dns-query`          | [Add to AdGuard](adguard:add_dns_server?address=https://doh.mullvad.net/dns-query&name=doh.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh.mullvad.net/dns-query&name=doh.mullvad.net) |
-| DNS-over-TLS   | `tls://doh.mullvad.net`           | [Add to AdGuard](adguard:add_dns_server?address=tls://doh.mullvad.net&name=doh.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://doh.mullvad.net&name=doh.mullvad.net) |
+| DNS-over-HTTPS | `https://dns.mullvad.net/dns-query`          | [Add to AdGuard](adguard:add_dns_server?address=https://dns.mullvad.net/dns-query&name=dns.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.mullvad.net/dns-query&name=dns.mullvad.net) |
+| DNS-over-TLS   | `tls://dns.mullvad.net`           | [Add to AdGuard](adguard:add_dns_server?address=tls://dns.mullvad.net&name=dns.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dns.mullvad.net&name=dns.mullvad.net) |
 
 #### Ad blocking
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS-over-HTTPS | `https://adblock.doh.mullvad.net/dns-query`          | [Add to AdGuard](adguard:add_dns_server?address=https://adblock.doh.mullvad.net/dns-query&name=adblock.doh.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://adblock.doh.mullvad.net/dns-query&name=adblock.doh.mullvad.net) |
-| DNS-over-TLS   | `tls://adblock.doh.mullvad.net`           | [Add to AdGuard](adguard:add_dns_server?address=tls://adblock.doh.mullvad.net&name=adblock.doh.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://adblock.doh.mullvad.net&name=adblock.doh.mullvad.net) |
+| DNS-over-HTTPS | `https://adblock.dns.mullvad.net/dns-query`          | [Add to AdGuard](adguard:add_dns_server?address=https://adblock.dns.mullvad.net/dns-query&name=adblock.dns.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://adblock.dns.mullvad.net/dns-query&name=adblock.dns.mullvad.net) |
+| DNS-over-TLS   | `tls://adblock.dns.mullvad.net`           | [Add to AdGuard](adguard:add_dns_server?address=tls://adblock.dns.mullvad.net&name=adblock.dns.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://adblock.dns.mullvad.net&name=adblock.dns.mullvad.net) |
 
 ### Nawala Childprotection DNS
 

--- a/docs/general/dns-providers.md
+++ b/docs/general/dns-providers.md
@@ -264,7 +264,7 @@ Blocks phishing, spam and malicious domains.
 | DNS, IPv6      | `2606:4700:4700::1111` and `2606:4700:4700::1001`  | [Add to AdGuard](adguard:add_dns_server?address=2606:4700:4700::1111&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2606:4700:4700::1111&name=) |
 | DNS-over-HTTPS, IPv4 | `https://dns.cloudflare.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.cloudflare.com/dns-query&name=dns.cloudflare.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.cloudflare.com/dns-query&name=dns.cloudflare.com) |
 | DNS-over-HTTPS, IPv6 | `https://dns.cloudflare.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.cloudflare.com:53/dns-query&name=dns.cloudflare.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.cloudflare.com:53/dns-query&name=dns.cloudflare.com) |
-| DNS-over-TLS | `tls://1dot1dot1dot1.cloudflare-dns.com` | [Add to AdGuard](adguard:add_dns_server?address=tls://1dot1dot1dot1.cloudflare-dns.com&name=1dot1dot1dot1.cloudflare-dns.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://1dot1dot1dot1.cloudflare-dns.com&name=1dot1dot1dot1.cloudflare-dns.com) |
+| DNS-over-TLS | `tls://one.one.one.one` | [Add to AdGuard](adguard:add_dns_server?address=tls://one.one.one.on&name=one.one.one.on), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://one.one.one.on&name=one.one.one.on) |
 
 #### Malware blocking only
 

--- a/docs/general/dns-providers.md
+++ b/docs/general/dns-providers.md
@@ -464,6 +464,34 @@ Hurricane Electric Public Recursor is a free alternative DNS service by Hurrican
 | DNS-over-HTTPS | `https://adblock.dns.mullvad.net/dns-query`          | [Add to AdGuard](adguard:add_dns_server?address=https://adblock.dns.mullvad.net/dns-query&name=adblock.dns.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://adblock.dns.mullvad.net/dns-query&name=adblock.dns.mullvad.net) |
 | DNS-over-TLS   | `tls://adblock.dns.mullvad.net`           | [Add to AdGuard](adguard:add_dns_server?address=tls://adblock.dns.mullvad.net&name=adblock.dns.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://adblock.dns.mullvad.net&name=adblock.dns.mullvad.net) |
 
+#### Ad + malware blocking
+
+| Protocol       | Address                                            |                |
+|----------------|----------------------------------------------------|----------------|
+| DNS-over-HTTPS | `https://base.dns.mullvad.net/dns-query`          | [Add to AdGuard](adguard:add_dns_server?address=https://base.dns.mullvad.net/dns-query&name=base.dns.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://base.dns.mullvad.net/dns-query&name=base.dns.mullvad.net) |
+| DNS-over-TLS   | `tls://base.dns.mullvad.net`           | [Add to AdGuard](adguard:add_dns_server?address=tls://base.dns.mullvad.net&name=base.dns.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://base.dns.mullvad.net&name=base.dns.mullvad.net) |
+
+#### Ad + malware + social media blocking
+
+| Protocol       | Address                                            |                |
+|----------------|----------------------------------------------------|----------------|
+| DNS-over-HTTPS | `https://extended.dns.mullvad.net/dns-query`          | [Add to AdGuard](adguard:add_dns_server?address=https://extended.dns.mullvad.net/dns-query&name=extended.dns.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://extended.dns.mullvad.net/dns-query&name=extended.dns.mullvad.net) |
+| DNS-over-TLS   | `tls://extended.dns.mullvad.net`           | [Add to AdGuard](adguard:add_dns_server?address=tls://extended.dns.mullvad.net&name=extended.dns.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://extended.dns.mullvad.net&name=extended.dns.mullvad.net) |
+
+#### Ad + malware + adult + gambling blocking
+
+| Protocol       | Address                                            |                |
+|----------------|----------------------------------------------------|----------------|
+| DNS-over-HTTPS | `https://family.dns.mullvad.net/dns-query`          | [Add to AdGuard](adguard:add_dns_server?address=https://family.dns.mullvad.net/dns-query&name=family.dns.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://family.dns.mullvad.net/dns-query&name=family.dns.mullvad.net) |
+| DNS-over-TLS   | `tls://family.dns.mullvad.net`           | [Add to AdGuard](adguard:add_dns_server?address=tls://family.dns.mullvad.net&name=family.dns.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://family.dns.mullvad.net&name=family.dns.mullvad.net) |
+
+#### Ad + malware + adult + gambling + social media blocking
+
+| Protocol       | Address                                            |                |
+|----------------|----------------------------------------------------|----------------|
+| DNS-over-HTTPS | `https://all.dns.mullvad.net/dns-query`          | [Add to AdGuard](adguard:add_dns_server?address=https://all.dns.mullvad.net/dns-query&name=all.dns.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://all.dns.mullvad.net/dns-query&name=all.dns.mullvad.net) |
+| DNS-over-TLS   | `tls://all.dns.mullvad.net`           | [Add to AdGuard](adguard:add_dns_server?address=tls://all.dns.mullvad.net&name=all.dns.mullvad.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://all.dns.mullvad.net&name=all.dns.mullvad.net) |
+
 ### Nawala Childprotection DNS
 
 [Nawala Childprotection DNS](http://nawala.id/) is an anycast Internet filtering system that protects children from inappropriate websites and abusive contents.


### PR DESCRIPTION
updated various DNS providers with new information

- Cloudflare DoT changed to one.one.one.one
- updated DNS.SB DoT hostname 
- updated Mullvad hostname due to old one due to be deprecated
- added in other Mullvad options & updated available countries