### PR TITLE
Use a custom ul style to work around docusaurus bugs

### DIFF
--- a/docs/dns-client/configuration.md
+++ b/docs/dns-client/configuration.md
@@ -3,11 +3,13 @@ title: Configuration file
 sidebar_position: 2
 ---
 
+<!-- markdownlint-configure-file {"ul-indent":{"indent":4,"start_indent":2,"start_indented":true}} -->
+
 See file [`config.dist.yml`][dist] for a full example of a [YAML][yaml] configuration file with comments.
 
 <!--
     TODO(a.garipov): Find ways to add IDs to individual list items.
- -->
+-->
 
 [dist]: https://github.com/AdguardTeam/AdGuardDNSClient/blob/master/config.dist.yaml
 [yaml]: https://yaml.org/
@@ -20,15 +22,15 @@ The `dns` object configures the behavior of the DNS server. It has the following
 
 The `cache` object configures caching the results of querying DNS. It has the following properties:
 
-- `enabled`: Whether or not the DNS results should be cached.
+  - `enabled`: Whether or not the DNS results should be cached.
 
     **Example:** `true`
 
-- `size`: The maximum size of the DNS result cache as human-readable data size. It must be greater than zero if `enabled` is `true`.
+  - `size`: The maximum size of the DNS result cache as human-readable data size. It must be greater than zero if `enabled` is `true`.
 
     **Example:** `128MB`
 
-- `client_size`: The maximum size of the DNS result cache for each configured client’s address or subnetwork as human-readable data size. It must be greater than zero if `enabled` is `true`.
+  - `client_size`: The maximum size of the DNS result cache for each configured client’s address or subnetwork as human-readable data size. It must be greater than zero if `enabled` is `true`.
 
     **Example:** `4MB`
 
@@ -36,31 +38,31 @@ The `cache` object configures caching the results of querying DNS. It has the fo
 
 The `server` object configures the handling of incoming requests. It has the following properties:
 
-- `listen_addresses`: The set of addresses with ports to listen on.
+  - `listen_addresses`: The set of addresses with ports to listen on.
 
     **Property example:**
 
     ```yaml
     'listen_addresses':
-      - address: '127.0.0.1:53'
-      - address: '[::1]:53'
+        - address: '127.0.0.1:53'
+        - address: '[::1]:53'
     ```
 
 ### `bootstrap` {#dns-bootstrap}
 
 The `bootstrap` object configures the resolution of [upstream](#dns-upstream) server addresses. It has the following properties:
 
-- `servers`: The list of servers to resolve the hostnames of upstream servers.
+  - `servers`: The list of servers to resolve the hostnames of upstream servers.
 
     **Property example:**
 
     ```yaml
     'servers':
-      - address: '8.8.8.8:53'
-      - address: '192.168.1.1:53'
+        - address: '8.8.8.8:53'
+        - address: '192.168.1.1:53'
     ```
 
-- `timeout`: The timeout for bootstrap DNS requests as a human-readable duration.
+  - `timeout`: The timeout for bootstrap DNS requests as a human-readable duration.
 
     **Example:** `2s`
 
@@ -68,19 +70,19 @@ The `bootstrap` object configures the resolution of [upstream](#dns-upstream) se
 
 The `upstream` object configures the actual resolving of requests. It has the following properties:
 
-- `groups`: The set of upstream servers keyed by the group’s name. It has the following fields:
+  - `groups`: The set of upstream servers keyed by the group’s name. It has the following fields:
 
-    - `address`: The upstream server’s address.
+      - `address`: The upstream server’s address.
 
         **Example:** `'8.8.8.8:53'`
 
-    - `match`: The list of criteria to match the request against. Each entry may contain the following properties:
+      - `match`: The list of criteria to match the request against. Each entry may contain the following properties:
 
-        - `question_domain`: The domain or a suffix of the domain that the set of upstream servers should be used to resolve.
+          - `question_domain`: The domain or a suffix of the domain that the set of upstream servers should be used to resolve.
 
             **Example:** `'mycompany.local'`
 
-        - `client`: The client’s address or a subnet of the client’s address from which the set of upstream servers should resolve requests. It must have no significant bits outside the subnet mask.
+          - `client`: The client’s address or a subnet of the client’s address from which the set of upstream servers should resolve requests. It must have no significant bits outside the subnet mask.
 
             **Example:** `'192.0.2.0/24'`
 
@@ -94,10 +96,10 @@ The `upstream` object configures the actual resolving of requests. It has the fo
 
         ```yaml
         'match':
-          - question_domain: 'mycompany.local'
+            - question_domain: 'mycompany.local'
             client: '192.168.1.0/24'
-          - question_domain: 'mycompany.external'
-          - client: '1.2.3.4'
+            - question_domain: 'mycompany.external'
+            - client: '1.2.3.4'
         ```
 
     :::info
@@ -108,7 +110,7 @@ The `upstream` object configures the actual resolving of requests. It has the fo
 
     The `default` group will be used when there are no matches among other groups. The `private` group will be used to resolve the PTR requests for the private IP addresses. Such queries will be answered with `NXDOMAIN` if no `private` group is defined.
 
-- `timeout`: The timeout for upstream DNS requests as a human-readable duration.
+  - `timeout`: The timeout for upstream DNS requests as a human-readable duration.
 
     **Example:** `2s`
 
@@ -116,16 +118,16 @@ The `upstream` object configures the actual resolving of requests. It has the fo
 
 The `fallback` object configures the behavior of the DNS server in case of failure. It has the following properties:
 
-- `servers`: The list of servers to use after the actual [upstream](#dns-upstream) failed to respond.
+  - `servers`: The list of servers to use after the actual [upstream](#dns-upstream) failed to respond.
 
     **Property example:**
 
     ```yaml
     'servers':
-      - address: 'tls://94.140.14.140'
+        - address: 'tls://94.140.14.140'
     ```
 
-- `timeout`: The timeout for fallback DNS requests as a human-readable duration.
+  - `timeout`: The timeout for fallback DNS requests as a human-readable duration.
 
     **Example:** `2s`
 
@@ -137,11 +139,11 @@ The `debug` object configures the debugging features. It has the following prope
 
 The `pprof` object configures the [`pprof`][pkg-pprof] HTTP handlers. It has the following properties:
 
-- `port`: The port to listen on for debug HTTP requests on localhost.
+  - `port`: The port to listen on for debug HTTP requests on localhost.
 
     **Example:** `6060`
 
-- `enabled`: Whether or not the debug profiling is enabled.
+  - `enabled`: Whether or not the debug profiling is enabled.
 
     **Example:** `true`
 
@@ -151,7 +153,7 @@ The `pprof` object configures the [`pprof`][pkg-pprof] HTTP handlers. It has the
 
 The `log` object configures the logging. It has the following properties:
 
-- `output`: The output to which logs are written.
+  - `output`: The output to which logs are written.
 
     :::note
 
@@ -161,13 +163,13 @@ The `log` object configures the logging. It has the following properties:
 
     Possible values:
 
-    - `syslog` means that the platform-specific system log is used, which is syslog for Linux and Event Log for Windows.
+      - `syslog` means that the platform-specific system log is used, which is syslog for Linux and Event Log for Windows.
 
-    - `stdout` for standard output stream.
+      - `stdout` for standard output stream.
 
-    - `stderr` for standard error stream.
+      - `stderr` for standard error stream.
 
-    - Absolute path to the log file.
+      - Absolute path to the log file.
 
       **Example:** `/home/user/logs`
 
@@ -175,15 +177,15 @@ The `log` object configures the logging. It has the following properties:
 
     **Example:** `syslog`
 
-- `format`: Specifies the format of the log entries.
+  - `format`: Specifies the format of the log entries.
 
     Possible values:
 
-    - `adguard_legacy`
-    - `default`
-    - `json`
-    - `jsonhybrid`
-    - `text`
+      - `adguard_legacy`
+      - `default`
+      - `json`
+      - `jsonhybrid`
+      - `text`
 
     **Example:** `default`
 
@@ -191,10 +193,10 @@ The `log` object configures the logging. It has the following properties:
         TODO(s.chzhen):  Add output examples.
     -->
 
-- `timestamp`: Specifies whether to include a timestamp in the log entries.
+  - `timestamp`: Specifies whether to include a timestamp in the log entries.
 
     **Example:** `false`
 
-- `verbose`: Specifies whether the log should be more informative.
+  - `verbose`: Specifies whether the log should be more informative.
 
     **Example:** `false`

--- a/docs/dns-client/environment.md
+++ b/docs/dns-client/environment.md
@@ -3,6 +3,8 @@ title: Environment
 sidebar_position: 3
 ---
 
+<!-- markdownlint-configure-file {"ul-indent":{"indent":4,"start_indent":2,"start_indented":true}} -->
+
 AdGuard DNS Client uses [environment variables][wiki-env] to store part of the configuration. The rest of the configuration is stored in the [configuration file][conf].
 
 [conf]:     configuration.md
@@ -12,7 +14,7 @@ AdGuard DNS Client uses [environment variables][wiki-env] to store part of the c
 
 The log destination, must be an absolute path to the file or one of the special values.
 
-- `syslog` means that the platform-specific system log is used, which is syslog for Linux and Event Log for Windows.
+  - `syslog` means that the platform-specific system log is used, which is syslog for Linux and Event Log for Windows.
 
     :::note
 
@@ -20,11 +22,11 @@ The log destination, must be an absolute path to the file or one of the special 
 
     :::
 
-- `stdout` for standard output stream.
+  - `stdout` for standard output stream.
 
-- `stderr` for standard error stream.
+  - `stderr` for standard error stream.
 
-- Absolute path to the log file.
+  - Absolute path to the log file.
 
     **Example:** `/home/user/logs.txt`
 
@@ -40,11 +42,11 @@ This environment variable has priority over the [log.output][conf-log] field in 
 
 The format for log entries.  Valid formats are:
 
-- `adguard_legacy`
-- `default`
-- `json`
-- `json_hybrid`
-- `text`
+  - `adguard_legacy`
+  - `default`
+  - `json`
+  - `json_hybrid`
+  - `text`
 
 <!--
     TODO(s.chzhen):  Add output examples.

--- a/docs/dns-client/overview.md
+++ b/docs/dns-client/overview.md
@@ -3,6 +3,8 @@ title: Overview
 sidebar_position: 1
 ---
 
+<!-- markdownlint-configure-file {"ul-indent":{"indent":4,"start_indent":2,"start_indented":true}} -->
+
 ## What is AdGuard DNS Client?
 
 A cross-platform lightweight DNS client for [AdGuard DNS][agdns]. It operates as a DNS server that forwards DNS requests to the corresponding upstream resolvers.
@@ -19,15 +21,15 @@ AdGuard DNS Client is still in the Beta stage. It may be unstable.
 
 Supported operating systems:
 
-- Linux
-- macOS
-- Windows
+  - Linux
+  - macOS
+  - Windows
 
 Supported CPU architectures:
 
-- 64-bit ARM
-- AMD64
-- i386
+  - 64-bit ARM
+  - AMD64
+  - i386
 
 ## Getting started {#start-basic}
 
@@ -79,12 +81,12 @@ Option `-h` makes AdGuard DNS Client print out a help message to standard output
 
 Option `-s <value>` specifies the OS service action. Possible values are:
 
-- `install`: installs AdGuard DNS Client as a service
-- `restart`: restarts the running AdGuard DNS Client service
-- `start`: starts the installed AdGuard DNS Client service
-- `status`: shows the status of the installed AdGuard DNS Client service
-- `stop`: stops the running AdGuard DNS Client
-- `uninstall`: uninstalls AdGuard DNS Client service
+  - `install`: installs AdGuard DNS Client as a service
+  - `restart`: restarts the running AdGuard DNS Client service
+  - `start`: starts the installed AdGuard DNS Client service
+  - `status`: shows the status of the installed AdGuard DNS Client service
+  - `stop`: stops the running AdGuard DNS Client
+  - `uninstall`: uninstalls AdGuard DNS Client service
 
 ### Verbose {#opts-verbose}
 
@@ -107,8 +109,8 @@ The YAML configuration file is described in [its own article][conf], and there i
 
 There are a few different exit codes that may appear under different error conditions:
 
-- `0`: Successfully finished and exited, no errors.
+  - `0`: Successfully finished and exited, no errors.
 
-- `1`: Internal error, most likely a misconfiguration.
+  - `1`: Internal error, most likely a misconfiguration.
 
-- `2`: Bad command-line argument or value.
+  - `2`: Bad command-line argument or value.


### PR DESCRIPTION
Adding the two spaces before the dash in unordered lists forces the content to be aligned to the Magic Number Four, which makes it easier for Docusaurus to render it correctly, notes and all.