### PR TITLE
Add AdGuard Home environment variables page

### DIFF
--- a/docs/adguard-home/environment.md
+++ b/docs/adguard-home/environment.md
@@ -5,7 +5,7 @@ sidebar_position: 5
 
 This page lists the supported environment variables and their descriptions.
 
-### `ADGUARD_HOME_DEFAULT_WEB_PORT`
+## `ADGUARD_HOME_DEFAULT_WEB_PORT` {#ADGUARD_HOME_DEFAULT_WEB_PORT}
 
 Sets the suggested default HTTP port displayed in the installation wizard.
 


### PR DESCRIPTION
Add an environment variables page to the AdGuard Home section of the knowledge base.