### PR TITLE
Update fritzbox.md to make clearer the two configuration options

### DIFF
--- a/docs/private-dns/connect-devices/routers/fritzbox.md
+++ b/docs/private-dns/connect-devices/routers/fritzbox.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 
 FRITZ!Box provides maximum flexibility for all devices by simultaneously using the 2.4 GHz and 5 GHz frequency bands. All devices connected to the FRITZ!Box are fully protected against attacks from the Internet. The configuration of this brand of routers also allows you to set up encrypted Private AdGuard DNS.
 
-## Configure DNS-over-TLS
+## If your FritzBox router supports DNS-over-TLS
 
 1. Open the router admin panel. It can be accessed at fritz.box, the IP address of your router, or `192.168.178.1`.
 1. Enter the administrator username (usually, it’s admin) and router password.
@@ -15,9 +15,8 @@ FRITZ!Box provides maximum flexibility for all devices by simultaneously using t
 1. Select *Use Custom TLS Server Name Indication (SNI)* and enter the AdGuard Private DNS server address:  `{Your_Device_ID}.d.adguard-dns.com`.
 1. Save the settings.
 
-## Use your router admin panel
 
-Use this guide if your FritzBox router does not support DNS-over-TLS configuration:
+## Alternatively, if your FritzBox router does not support DNS-over-TLS
 
 1. Open the router admin panel. It can be accessed at `192.168.1.1` or `192.168.0.1`.
 1. Enter the administrator username (usually, it’s admin) and router password.


### PR DESCRIPTION
The previous instructions had a clear heading for the first option, when DNS-over-TLS is available. The second option, for when DNS-over-TLS is unavailable, had the heading "Use your router admin panel"; that doesn't make clear that this is the alternative path to configure the router.