### PR TITLE
docs: clarify capability needs DNS vs. DHCP+DNS

### DIFF
--- a/docs/adguard-home/getting-started.md
+++ b/docs/adguard-home/getting-started.md
@@ -226,6 +226,14 @@ Using this method requires the `setcap` utility. You may need to install it usin
 
 To allow AdGuard Home running on Linux to listen on port 53 without superuser privileges and bind its DNS servers to a particular interface, run:
 
+- For DNS-only mode:
+
+```sh
+sudo setcap 'CAP_NET_BIND_SERVICE=+eip' ./AdGuardHome
+```
+
+- For DHCP and DNS mode (additional requirement of `CAP_NET_RAW`):
+
 ```sh
 sudo setcap 'CAP_NET_BIND_SERVICE=+eip CAP_NET_RAW=+eip' ./AdGuardHome
 ```


### PR DESCRIPTION
`CAP_NET_RAW` is only required when running AdGuard Home with DHCP server enabled. Split the setcap instructions to show:
- DNS-only mode: requires only `CAP_NET_BIND_SERVICE`
- DHCP+DNS mode: requires both `CAP_NET_BIND_SERVICE` and `CAP_NET_RAW`

Verified running as non-root with just `CAP_NET_BIND_SERVICE` and DNS-only works fine.
```
% lsof -i :53
COMMAND   PID        USER FD   TYPE  DEVICE SIZE/OFF NODE NAME
adguardho 183 adguardhome 12u  IPv6 1469109      0t0  UDP *:domain
adguardho 183 adguardhome 23u  IPv6 1469110      0t0  TCP *:domain (LISTEN)
```