### PR TITLE
Update mdm-config.md - clarify step about dnsproxy MAC parameter

### DIFF
--- a/docs/private-dns/connect-devices/other-options/mdm-config.md
+++ b/docs/private-dns/connect-devices/other-options/mdm-config.md
@@ -62,7 +62,7 @@ When configuring via MDM, set `com.adguard.dnsclient` as `Always-on` and add `Lo
 
 ### On iOS
 
-On iOS, AdGuard DNS uses a DNS proxy to enforce DNS policies and stay **always on** for supervised devices. To enable this, create a `mobileconfig` for the device and deploy it via MDM.
+On iOS, AdGuard DNS uses a DNS proxy to enforce DNS policies and stay **always on** for supervised devices. To enable this, create a `mobileconfig` for the device and deploy it via MDM. For MAC’s `dns_protocol` parameter, use `doh_dnsproxy`, `dot_dnsproxy`, or `doq_dnsproxy`.
 
 :::important
 


### PR DESCRIPTION
Clarifying the instruction: to use DNS proxy mobileconfig, admin needs to use _dnsproxy MAC parameters