### PR TITLE
docs/general/dns-providers.md: comprehensive cleanup — dead providers, broken links, grammar, sorting

### DIFF
--- a/docs/general/dns-providers.md
+++ b/docs/general/dns-providers.md
@@ -63,33 +63,32 @@ Each of these servers provides a secure and reliable connection, but unlike the 
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt.unfiltered.ns1.adguard.com` IP: `94.140.14.140:5443`| [Add to AdGuard](sdns://AQIAAAAAAAAAFlsyYTEwOjUwYzA6OjE6ZmZdOjU0NDMgtehE1rg6Pj4SaOtoH76nDePF-mjb1ogUHb8uwGay2volMi5kbnNjcnlwdC51bmZpbHRlcmVkLm5zMS5hZGd1YXJkLmNvbQ) |
 | DNSCrypt, IPv6 |  Provider: `2.dnscrypt.unfiltered.ns1.adguard.com` IP: `[2a10:50c0::1:ff]:5443`| [Add to AdGuard](sdns://AQIAAAAAAAAAF1syYTAwOjVhNjA6OjAxOmZmXTo1NDQzIIHQAtNqTKUMRzt0eWUP4S4CsyHLYThWKiCOQD39xV6UIjIuZG5zY3J5cHQuZGVmYXVsdC5uczIuYWRndWFyZC5jb20) |
 
-### Ali DNS
+### 360 Secure DNS
 
-[Ali DNS](https://alidns.com/) is a free recursive DNS service that committed to providing fast, stable and secure DNS resolution for the majority of Internet users. It includes AliGuard facility to protect users from various attacks and threats.
+**360 Secure DNS** is a industry-leading recursive DNS service with advanced network security threat protection.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `223.5.5.5` and `223.6.6.6`                        | [Add to AdGuard](adguard:add_dns_server?address=223.5.5.5&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=223.5.5.5&name=) |
-| DNS, IPv6      | `2400:3200::1` and `2400:3200:baba::1`             | [Add to AdGuard](adguard:add_dns_server?address=2400:3200::1&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2400:3200::1&name=) |
+| DNS, IPv4      | `101.226.4.6` and `218.30.118.6`                   | [Add to AdGuard](adguard:add_dns_server?address=101.226.4.6&name=360%20Secure%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=101.226.4.6&name=360%20Secure%20DNS) |
+| DNS, IPv4      | `123.125.81.6` and `140.207.198.6`                 | [Add to AdGuard](adguard:add_dns_server?address=123.125.81.6&name=360%20Secure%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=123.125.81.6&name=360%20Secure%20DNS) |
+| DNS-over-HTTPS | `https://doh.360.cn/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://doh.360.cn/dns-query&name=doh.360.cn), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh.360.cn/dns-query&name=doh.360.cn) |
+| DNS-over-TLS | `tls://dot.360.cn` | [Add to AdGuard](adguard:add_dns_server?address=tls://dot.360.cn&name=dot.360.cn), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dot.360.cn&name=dot.360.cn) |
+
+### Ali DNS
+
+[Ali DNS](https://alidns.com/) is a free recursive DNS service that is committed to providing fast, stable and secure DNS resolution for the majority of Internet users. It includes AliGuard facility to protect users from various attacks and threats.
+
+| Protocol       | Address                                            |                |
+|----------------|----------------------------------------------------|----------------|
+| DNS, IPv4      | `223.5.5.5` and `223.6.6.6`                        | [Add to AdGuard](adguard:add_dns_server?address=223.5.5.5&name=Ali%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=223.5.5.5&name=Ali%20DNS) |
+| DNS, IPv6      | `2400:3200::1` and `2400:3200:baba::1`             | [Add to AdGuard](adguard:add_dns_server?address=2400:3200::1&name=Ali%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2400:3200::1&name=Ali%20DNS) |
 | DNS-over-HTTPS | `https://dns.alidns.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.alidns.com/dns-query&name=dns.alidns.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.alidns.com/dns-query&name=dns.alidns.com) |
 | DNS-over-TLS | `tls://dns.alidns.com` | [Add to AdGuard](adguard:add_dns_server?address=tls://dns.alidns.com&name=dns.alidns.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dns.alidns.com&name=dns.alidns.com) |
 | DNS-over-QUIC | `quic://dns.alidns.com:853` | [Add to AdGuard](adguard:add_dns_server?address=quic://dns.alidns.com:853&name=dns.alidns.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=quic://dns.alidns.com:853&name=dns.alidns.com:853) |
 
-### Caliph DNS
-
- [Caliph DNS](https://dns.caliph.dev) is a free DNS service based in Indonesia to surf the Internet safely and without worries.
-
- | Type            | Address                                              |                                                                                                                               |
- |-----------------|------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
- | DNS, IPv4       | `160.19.167.150`                                    | [Add to AdGuard](adguard:add_dns_server?address=160.19.167.150&name=160.19.167.150), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=160.19.167.150&name=160.19.167.150) |
- | DNS, IPv6       | `2001:df7:5300:3::51e`                 | [Add to AdGuard](adguard:add_dns_server?address=2001:df7:5300:3::51e&name=2001:df7:5300:3::51e), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:df7:5300:3::51e&name=2001:df7:5300:3::51e) |
- | DNS-over-HTTPS  | `https://dns.caliph.dev/dns-query`                   | [Add to AdGuard](adguard:add_dns_server?address=https://dns.caliph.dev/dns-query&name=dns.caliph.dev), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.caliph.dev/dns-query&name=dns.caliph.dev) |
- | DNS-over-TLS    | `tls://dns.caliph.dev:853`                           | [Add to AdGuard](adguard:add_dns_server?address=dns.caliph.dev:853&name=dns.caliph.dev:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=dns.caliph.dev:853&name=dns.caliph.dev:853) |
- | DNS-over-QUIC   | `quic://dns.caliph.dev:853`                          | [Add to AdGuard](adguard:add_dns_server?address=quic://dns.caliph.dev:853&name=dns.caliph.dev:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=quic://dns.caliph.dev:853&name=dns.caliph.dev:853) |
-
 ### BebasDNS by BebasID
 
-[BebasDNS](https://github.com/bebasid/bebasdns) is a free and neutral public resolver based in Indonesia which supports OpenNIC domain. Created by Komunitas Internet Netral Indonesia (KINI) to serve Indonesian user with free and neutral internet connection.
+[BebasDNS](https://github.com/bebasid/bebasdns) is a free and neutral public resolver based in Indonesia which supports OpenNIC domain. Created by Komunitas Internet Netral Indonesia (KINI) to serve Indonesian users with free and neutral internet connection.
 
 #### Default
 
@@ -98,7 +97,7 @@ This is the default variant of BebasDNS. This variant blocks ads, malware, and p
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
 | DNS-over-HTTPS | `https://dns.bebasid.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.bebasid.com/dns-query&name=dns.bebasid.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.bebasid.com/dns-query&name=dns.bebasid.com) |
-| DNS-over-TLS   | `tls://dns.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=dns.bebasid.com:853&name=dns.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=dns.bebasid.com:853&name=dns.bebasid.com:853) |
+| DNS-over-TLS   | `tls://dns.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=tls://dns.bebasid.com:853&name=dns.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dns.bebasid.com:853&name=dns.bebasid.com:853) |
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.dns.bebasid.com` IP: `103.87.68.194:8443` | [Add to AdGuard](sdns://AQMAAAAAAAAAEjEwMy44Ny42OC4xOTQ6ODQ0MyAxXDKkdrOao8ZeLyu7vTnVrT0C7YlPNNf6trdMkje7QR8yLmRuc2NyeXB0LWNlcnQuZG5zLmJlYmFzaWQuY29t) |
 
 #### Unfiltered
@@ -108,7 +107,7 @@ This variant doesn’t filter anything.
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
 | DNS-over-HTTPS | `https://dns.bebasid.com/unfiltered` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.bebasid.com/unfiltered&name=dns.bebasid.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.bebasid.com/unfiltered&name=dns.bebasid.com) |
-| DNS-over-TLS   | `tls://unfiltered.dns.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=unfiltered.dns.bebasid.com:853&name=unfiltered.dns.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=unfiltered.dns.bebasid.com:853&name=unfiltered.dns.bebasid.com:853) |
+| DNS-over-TLS   | `tls://unfiltered.dns.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=tls://unfiltered.dns.bebasid.com:853&name=unfiltered.dns.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://unfiltered.dns.bebasid.com:853&name=unfiltered.dns.bebasid.com:853) |
 
 #### Security
 
@@ -117,54 +116,56 @@ This is the security/antivirus variant of BebasDNS. This variant only blocks mal
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
 | DNS-over-HTTPS | `https://antivirus.bebasid.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://antivirus.bebasid.com/dns-query&name=antivirus.bebasid.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://antivirus.bebasid.com/dns-query&name=antivirus.bebasid.com) |
-| DNS-over-TLS   | `tls://antivirus.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=antivirus.bebasid.com:853&name=antivirus.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=antivirus.bebasid.com:853&name=antivirus.bebasid.com:853) |
+| DNS-over-TLS   | `tls://antivirus.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=tls://antivirus.bebasid.com:853&name=antivirus.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://antivirus.bebasid.com:853&name=antivirus.bebasid.com:853) |
 
 #### Family
 
-This is the family variant of BebasDNS. This variant blocks pornography, gambling, hate site, blocks malware, and phishing domains.
+This is the family variant of BebasDNS. This variant blocks pornography, gambling, hate sites, malware, and phishing domains.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
 | DNS-over-HTTPS | `https://internetsehat.bebasid.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://internetsehat.bebasid.com/dns-query&name=internetsehat.bebasid.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://internetsehat.bebasid.com/dns-query&name=internetsehat.bebasid.com) |
-| DNS-over-TLS   | `tls://internetsehat.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=internetsehat.bebasid.com:853&name=internetsehat.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=internetsehat.bebasid.com:853&name=internetsehat.bebasid.com:853) |
+| DNS-over-TLS   | `tls://internetsehat.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=tls://internetsehat.bebasid.com:853&name=internetsehat.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://internetsehat.bebasid.com:853&name=internetsehat.bebasid.com:853) |
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.internetsehat.bebasid.com` IP: `103.87.68.196:8443` | [Add to AdGuard](sdns://AQMAAAAAAAAAEjEwMy44Ny42OC4xOTY6ODQ0MyD5k4vgIHmBCZ2DeLtmoDVu1C6nVrRNzSVgZ1T0m0-3rCkyLmRuc2NyeXB0LWNlcnQuaW50ZXJuZXRzZWhhdC5iZWJhc2lkLmNvbQ) |
 
 #### Family With Ad Filtering
 
-This is the family variant of BebasDNS but with adblocker
+This is the family variant of BebasDNS but with an ad blocker
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
 | DNS-over-HTTPS | `https://internetsehat.bebasid.com/adblock` | [Add to AdGuard](adguard:add_dns_server?address=https://internetsehat.bebasid.com/adblock&name=internetsehat.bebasid.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://internetsehat.bebasid.com/adblock&name=internetsehat.bebasid.com) |
-| DNS-over-TLS   | `tls://family-adblock.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=family-adblock.bebasid.com:853&name=family-adblock.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=family-adblock.bebasid.com:853&name=family-adblock.bebasid.com:853) |
+| DNS-over-TLS   | `tls://family-adblock.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=tls://family-adblock.bebasid.com:853&name=family-adblock.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://family-adblock.bebasid.com:853&name=family-adblock.bebasid.com:853) |
 
 #### OISD Filter
 
-This is a custom BebasDNS variant with only OISD Big filter
+This is a custom BebasDNS variant with only OISD Big Filter
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS-over-HTTPS | `https://dns.bebasid.com/dns-oisd` | [Add to AdGuard](adguard:add_dns_server?address=https://internetsehat.bebasid.com/adblock&name=internetsehat.bebasid.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://internetsehat.bebasid.com/adblock&name=internetsehat.bebasid.com) |
-| DNS-over-TLS   | `tls://oisd.dns.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=oisd.dns.bebasid.com:853&name=oisd.dns.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=oisd.dns.bebasid.com:853&name=oisd.dns.bebasid.com:853) |
+| DNS-over-HTTPS | `https://dns.bebasid.com/dns-oisd` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.bebasid.com/dns-oisd&name=dns.bebasid.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.bebasid.com/dns-oisd&name=dns.bebasid.com) |
+| DNS-over-TLS   | `tls://oisd.dns.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=tls://oisd.dns.bebasid.com:853&name=oisd.dns.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://oisd.dns.bebasid.com:853&name=oisd.dns.bebasid.com:853) |
 
 #### Hagezi Multi Normal Filter
 
-This is a custom BebasDNS variant with only Hagezi Multi Normal filter
+This is a custom BebasDNS variant with only Hagezi Multi Normal Filter
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS-over-HTTPS | `https://dns.bebasid.com/dns-hagezi` | [Add to AdGuard](adguard:add_dns_server?address=https://internetsehat.bebasid.com/adblock&name=internetsehat.bebasid.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://internetsehat.bebasid.com/adblock&name=internetsehat.bebasid.com) |
-| DNS-over-TLS   | `tls://hagezi.dns.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=hagezi.dns.bebasid.com:853&name=hagezi.dns.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=hagezi.dns.bebasid.com:853&name=hagezi.dns.bebasid.com:853) |
+| DNS-over-HTTPS | `https://dns.bebasid.com/dns-hagezi` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.bebasid.com/dns-hagezi&name=dns.bebasid.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.bebasid.com/dns-hagezi&name=dns.bebasid.com) |
+| DNS-over-TLS   | `tls://hagezi.dns.bebasid.com:853` | [Add to AdGuard](adguard:add_dns_server?address=tls://hagezi.dns.bebasid.com:853&name=hagezi.dns.bebasid.com:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://hagezi.dns.bebasid.com:853&name=hagezi.dns.bebasid.com:853) |
 
-### CFIEC Public DNS
+### Caliph DNS
 
-IPv6-based anycast DNS service with strong security capabilities and protection from spyware, malicious websites. It supports DNS64 to provide domain name resolution only for IPv6 users.
+[Caliph DNS](https://dns.caliph.dev) is a free DNS service based in Indonesia. Note: The website (https://dns.caliph.dev) is currently returning HTTP 502. The DNS service itself (DoH/DoT/DNS IPv4) remains functional. This service applies SafeSearch enforcement on Google queries and blocks certain websites (e.g., Reddit returns `internetpositif.id`).
 
-| Protocol       | Address                                            |                |
-|----------------|----------------------------------------------------|----------------|
-| DNS, IPv6      | `240C::6666` and `240C::6644`                      | [Add to AdGuard](adguard:add_dns_server?address=240C::6666&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=240C::6666&name=) |
-| DNS-over-HTTPS | `https://dns.cfiec.net/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.cfiec.net/dns-query&name=dns.cfiec.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.cfiec.net/dns-query&name=dns.cfiec.net) |
-| DNS-over-TLS | `tls://dns.cfiec.net` | [Add to AdGuard](adguard:add_dns_server?address=tls://tls://dns.cfiec.net&name=tls://dns.cfiec.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://tls://dns.cfiec.net&name=tls://dns.cfiec.net) |
+| Protocol            | Address                                              |                                                                                                                               |
+|-----------------|------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| DNS, IPv4       | `160.19.167.150`                                    | [Add to AdGuard](adguard:add_dns_server?address=160.19.167.150&name=Caliph%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=160.19.167.150&name=Caliph%20DNS) |
+| DNS, IPv6       | `2001:df7:5300:3::51e`                 | [Add to AdGuard](adguard:add_dns_server?address=2001:df7:5300:3::51e&name=Caliph%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:df7:5300:3::51e&name=Caliph%20DNS) |
+| DNS-over-HTTPS  | `https://dns.caliph.dev/dns-query`                   | [Add to AdGuard](adguard:add_dns_server?address=https://dns.caliph.dev/dns-query&name=dns.caliph.dev), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.caliph.dev/dns-query&name=dns.caliph.dev) |
+| DNS-over-TLS    | `tls://dns.caliph.dev:853`                           | [Add to AdGuard](adguard:add_dns_server?address=tls://dns.caliph.dev:853&name=dns.caliph.dev:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dns.caliph.dev:853&name=dns.caliph.dev:853) |
+| DNS-over-QUIC   | `quic://dns.caliph.dev:853`                          | [Add to AdGuard](adguard:add_dns_server?address=quic://dns.caliph.dev:853&name=dns.caliph.dev:853), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=quic://dns.caliph.dev:853&name=dns.caliph.dev:853) |
 
 ### Cisco OpenDNS
 
@@ -176,8 +177,8 @@ DNS servers with custom filtering that protects your device from malware.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `208.67.222.222` and `208.67.220.220`              | [Add to AdGuard](adguard:add_dns_server?address=208.67.222.222&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=208.67.222.222&name=) |
-| DNS, IPv6      | `2620:119:35::35` and `2620:119:53::53`            | [Add to AdGuard](adguard:add_dns_server?address=2620:119:35::35&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2620:119:35::35&name=) |
+| DNS, IPv4      | `208.67.222.222` and `208.67.220.220`              | [Add to AdGuard](adguard:add_dns_server?address=208.67.222.222&name=Cisco%20OpenDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=208.67.222.222&name=Cisco%20OpenDNS) |
+| DNS, IPv6      | `2620:119:35::35` and `2620:119:53::53`            | [Add to AdGuard](adguard:add_dns_server?address=2620:119:35::35&name=Cisco%20OpenDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2620:119:35::35&name=Cisco%20OpenDNS) |
 | DNSCrypt, IPv4 |  Provider: `2.dnscrypt-cert.opendns.com` IP: `208.67.220.220`| [Add to AdGuard](sdns://AQAAAAAAAAAADjIwOC42Ny4yMjAuMjIwILc1EUAgbyJdPivYItf9aR6hwzzI1maNDL4Ev6vKQ_t5GzIuZG5zY3J5cHQtY2VydC5vcGVuZG5zLmNvbQ) |
 | DNSCrypt, IPv6 |  Provider: `2.dnscrypt-cert.opendns.com` IP: `[2620:0:ccc::2]`| [Add to AdGuard](sdns://AQAAAAAAAAAAD1syNjIwOjA6Y2NjOjoyXSC3NRFAIG8iXT4r2CLX_WkeocM8yNZmjQy-BL-rykP7eRsyLmRuc2NyeXB0LWNlcnQub3BlbmRucy5jb20) |
 | DNS-over-HTTPS | `https://doh.opendns.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://doh.opendns.com/dns-query&name=doh.opendns.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh.opendns.com/dns-query&name=doh.opendns.com) |
@@ -189,7 +190,7 @@ OpenDNS servers that provide adult content blocking.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `208.67.222.123` and `208.67.220.123`              | [Add to AdGuard](adguard:add_dns_server?address=208.67.222.123&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=208.67.222.123&name=) |
+| DNS, IPv4      | `208.67.222.123` and `208.67.220.123`              | [Add to AdGuard](adguard:add_dns_server?address=208.67.222.123&name=Cisco%20OpenDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=208.67.222.123&name=Cisco%20OpenDNS) |
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.opendns.com` IP: `208.67.220.123`| [Add to AdGuard](sdns://AQAAAAAAAAAADjIwOC42Ny4yMjAuMTIzILc1EUAgbyJdPivYItf9aR6hwzzI1maNDL4Ev6vKQ_t5GzIuZG5zY3J5cHQtY2VydC5vcGVuZG5zLmNvbQ) |
 | DNS-over-HTTPS | `https://doh.familyshield.opendns.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://doh.familyshield.opendns.com/dns-query&name=doh.familyshield.opendns.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh.familyshield.opendns.com/dns-query&name=doh.familyshield.opendns.com) |
 | DNS-over-TLS | `tls://familyshield.opendns.com` | [Add to AdGuard](adguard:add_dns_server?address=tls://familyshield.opendns.com&name=familyshield.opendns.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://familyshield.opendns.com&name=familyshield.opendns.com) |
@@ -200,10 +201,10 @@ Non-filtering OpenDNS servers.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `208.67.222.2` and `208.67.220.2`                  | [Add to AdGuard](adguard:add_dns_server?address=208.67.220.2&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=208.67.222.2&name=) |
-| DNS, IPv6      | `2620:0:ccc::2` IP: `2620:0:ccd::2`| [Add to AdGuard](adguard:add_dns_server?address=2620:0:ccc::2&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2620:0:ccc::2&name=) |
+| DNS, IPv4      | `208.67.222.2` and `208.67.220.2`                  | [Add to AdGuard](adguard:add_dns_server?address=208.67.222.2&name=Cisco%20OpenDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=208.67.222.2&name=Cisco%20OpenDNS) |
+| DNS, IPv6      | `2620:0:ccc::2` IP: `2620:0:ccd::2`| [Add to AdGuard](adguard:add_dns_server?address=2620:0:ccc::2&name=Cisco%20OpenDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2620:0:ccc::2&name=Cisco%20OpenDNS) |
 | DNS-over-HTTPS | `https://doh.sandbox.opendns.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://doh.sandbox.opendns.com/dns-query&name=doh.sandbox.opendns.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh.sandbox.opendns.com/dns-query&name=doh.sandbox.opendns.com) |
-| DNS-over-TLS | `tls://sandbox.opendns.com` | [Add to AdGuard](adguard:add_dns_server?address=tls://sandbox.opendns.com&name=sandbox.opendns.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://sandbox.opendns.com/dns-query&name=sandbox.opendns.com) |
+| DNS-over-TLS | `tls://sandbox.opendns.com` | [Add to AdGuard](adguard:add_dns_server?address=tls://sandbox.opendns.com&name=sandbox.opendns.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://sandbox.opendns.com&name=sandbox.opendns.com) |
 
 :::info
 
@@ -221,8 +222,8 @@ Blocks access to all adult, pornographic and explicit sites, including proxy & V
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `185.228.168.168` and `185.228.169.168`            | [Add to AdGuard](adguard:add_dns_server?address=185.228.168.168&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=185.228.168.168&name=) |
-| DNS, IPv6      | `2a0d:2a00:1::` and `2a0d:2a00:2::`                | [Add to AdGuard](adguard:add_dns_server?address=2a0d:2a00:1::&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a0d:2a00:1::&name=) |
+| DNS, IPv4      | `185.228.168.168` and `185.228.169.168`            | [Add to AdGuard](adguard:add_dns_server?address=185.228.168.168&name=CleanBrowsing), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=185.228.168.168&name=CleanBrowsing) |
+| DNS, IPv6      | `2a0d:2a00:1::` and `2a0d:2a00:2::`                | [Add to AdGuard](adguard:add_dns_server?address=2a0d:2a00:1::&name=CleanBrowsing), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a0d:2a00:1::&name=CleanBrowsing) |
 | DNSCrypt, IPv4 | Provider: `cleanbrowsing.org` IP: `185.228.168.168:8443`| [Add to AdGuard](sdns://AQMAAAAAAAAAFDE4NS4yMjguMTY4LjE2ODo4NDQzILysMvrVQ2kXHwgy1gdQJ8MgjO7w6OmflBjcd2Bl1I8pEWNsZWFuYnJvd3Npbmcub3Jn)|
 | DNSCrypt, IPv6 | Provider: `cleanbrowsing.org` IP: `[2a0d:2a00:1::]:8443`| [Add to AdGuard](sdns://AQMAAAAAAAAAFFsyYTBkOjJhMDA6MTo6XTo4NDQzILysMvrVQ2kXHwgy1gdQJ8MgjO7w6OmflBjcd2Bl1I8pEWNsZWFuYnJvd3Npbmcub3Jn) |
 | DNS-over-HTTPS | `https://doh.cleanbrowsing.org/doh/family-filter/` | [Add to AdGuard](adguard:add_dns_server?address=https://doh.cleanbrowsing.org/doh/family-filter/&name=doh.cleanbrowsing.org), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh.cleanbrowsing.org/doh/family-filter/&name=doh.cleanbrowsing.org) |
@@ -234,8 +235,8 @@ Less restrictive than the Family filter, it only blocks access to adult content 
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `185.228.168.10` and `185.228.169.11`              | [Add to AdGuard](adguard:add_dns_server?address=185.228.168.10&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=185.228.168.10&name=) |
-| DNS, IPv6      | `2a0d:2a00:1::1` and `2a0d:2a00:2::1`              | [Add to AdGuard](adguard:add_dns_server?address=2a0d:2a00:1::1&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a0d:2a00:1::1&name=) |
+| DNS, IPv4      | `185.228.168.10` and `185.228.169.11`              | [Add to AdGuard](adguard:add_dns_server?address=185.228.168.10&name=CleanBrowsing), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=185.228.168.10&name=CleanBrowsing) |
+| DNS, IPv6      | `2a0d:2a00:1::1` and `2a0d:2a00:2::1`              | [Add to AdGuard](adguard:add_dns_server?address=2a0d:2a00:1::1&name=CleanBrowsing), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a0d:2a00:1::1&name=CleanBrowsing) |
 | DNSCrypt, IPv4 | Provider: `cleanbrowsing.org` IP: `185.228.168.10:8443`| [Add to AdGuard](sdns://AQMAAAAAAAAAEzE4NS4yMjguMTY4LjEwOjg0NDMgvKwy-tVDaRcfCDLWB1AnwyCM7vDo6Z-UGNx3YGXUjykRY2xlYW5icm93c2luZy5vcmc) |
 | DNSCrypt, IPv6 | Provider: `cleanbrowsing.org` IP: `[2a0d:2a00:1::1]:8443`| [Add to AdGuard](sdns://AQMAAAAAAAAAFVsyYTBkOjJhMDA6MTo6MV06ODQ0MyC8rDL61UNpFx8IMtYHUCfDIIzu8Ojpn5QY3HdgZdSPKRFjbGVhbmJyb3dzaW5nLm9yZw) |
 | DNS-over-HTTPS | `https://doh.cleanbrowsing.org/doh/adult-filter/`  | [Add to AdGuard](adguard:add_dns_server?address=https://doh.cleanbrowsing.org/doh/adult-filter/&name=doh.cleanbrowsing.org), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh.cleanbrowsing.org/doh/adult-filter/&name=doh.cleanbrowsing.org) |
@@ -247,8 +248,8 @@ Blocks phishing, spam and malicious domains.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `185.228.168.9` and `185.228.169.9`                | [Add to AdGuard](adguard:add_dns_server?address=185.228.168.9&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=185.228.168.9&name=) |
-| DNS, IPv6      | `2a0d:2a00:1::2` and `2a0d:2a00:2::2`              | [Add to AdGuard](adguard:add_dns_server?address=2a0d:2a00:1::2&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a0d:2a00:1::2&name=) |
+| DNS, IPv4      | `185.228.168.9` and `185.228.169.9`                | [Add to AdGuard](adguard:add_dns_server?address=185.228.168.9&name=CleanBrowsing), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=185.228.168.9&name=CleanBrowsing) |
+| DNS, IPv6      | `2a0d:2a00:1::2` and `2a0d:2a00:2::2`              | [Add to AdGuard](adguard:add_dns_server?address=2a0d:2a00:1::2&name=CleanBrowsing), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a0d:2a00:1::2&name=CleanBrowsing) |
 | DNS-over-HTTPS | `https://doh.cleanbrowsing.org/doh/security-filter/` | [Add to AdGuard](adguard:add_dns_server?address=https://doh.cleanbrowsing.org/doh/security-filter/&name=doh.cleanbrowsing.org), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh.cleanbrowsing.org/doh/security-filter/&name=doh.cleanbrowsing.org) |
 | DNS-over-TLS | `tls://security-filter-dns.cleanbrowsing.org` | [Add to AdGuard](adguard:add_dns_server?address=tls://security-filter-dns.cleanbrowsing.org&name=security-filter-dns.cleanbrowsing.org), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://security-filter-dns.cleanbrowsing.org&name=security-filter-dns.cleanbrowsing.org) |
 
@@ -260,8 +261,8 @@ Blocks phishing, spam and malicious domains.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `1.1.1.1` and `1.0.0.1`                            | [Add to AdGuard](adguard:add_dns_server?address=1.1.1.1&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=1.1.1.1&name=) |
-| DNS, IPv6      | `2606:4700:4700::1111` and `2606:4700:4700::1001`  | [Add to AdGuard](adguard:add_dns_server?address=2606:4700:4700::1111&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2606:4700:4700::1111&name=) |
+| DNS, IPv4      | `1.1.1.1` and `1.0.0.1`                            | [Add to AdGuard](adguard:add_dns_server?address=1.1.1.1&name=Cloudflare%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=1.1.1.1&name=Cloudflare%20DNS) |
+| DNS, IPv6      | `2606:4700:4700::1111` and `2606:4700:4700::1001`  | [Add to AdGuard](adguard:add_dns_server?address=2606:4700:4700::1111&name=Cloudflare%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2606:4700:4700::1111&name=Cloudflare%20DNS) |
 | DNS-over-HTTPS, IPv4 | `https://dns.cloudflare.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.cloudflare.com/dns-query&name=dns.cloudflare.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.cloudflare.com/dns-query&name=dns.cloudflare.com) |
 | DNS-over-HTTPS, IPv6 | `https://dns.cloudflare.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.cloudflare.com:53/dns-query&name=dns.cloudflare.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.cloudflare.com:53/dns-query&name=dns.cloudflare.com) |
 | DNS-over-TLS | `tls://one.one.one.one` | [Add to AdGuard](adguard:add_dns_server?address=tls://one.one.one.one&name=CloudflareDoT), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://one.one.one.one&name=CloudflareDoT) |
@@ -270,8 +271,8 @@ Blocks phishing, spam and malicious domains.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `1.1.1.2` and `1.0.0.2`                            | [Add to AdGuard](adguard:add_dns_server?address=1.1.1.2&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=1.1.1.2&name=) |
-| DNS, IPv6      | `2606:4700:4700::1112` and `2606:4700:4700::1002`  | [Add to AdGuard](adguard:add_dns_server?address=2606:4700:4700::1112&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2606:4700:4700::1112&name=) |
+| DNS, IPv4      | `1.1.1.2` and `1.0.0.2`                            | [Add to AdGuard](adguard:add_dns_server?address=1.1.1.2&name=Cloudflare%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=1.1.1.2&name=Cloudflare%20DNS) |
+| DNS, IPv6      | `2606:4700:4700::1112` and `2606:4700:4700::1002`  | [Add to AdGuard](adguard:add_dns_server?address=2606:4700:4700::1112&name=Cloudflare%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2606:4700:4700::1112&name=Cloudflare%20DNS) |
 | DNS-over-HTTPS| `https://security.cloudflare-dns.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://security.cloudflare-dns.com/dns-query&name=security.cloudflare-dns.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://security.cloudflare-dns.com/dns-query&name=security.cloudflare-dns.com) |
 | DNS-over-TLS | `tls://security.cloudflare-dns.com` | [Add to AdGuard](adguard:add_dns_server?address=tls://security.cloudflare-dns.com&name=security.cloudflare-dns.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://security.cloudflare-dns.com&name=security.cloudflare-dns.com) |
 
@@ -279,8 +280,8 @@ Blocks phishing, spam and malicious domains.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `1.1.1.3` and `1.0.0.3`                            | [Add to AdGuard](adguard:add_dns_server?address=1.1.1.3&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=1.1.1.3&name=) |
-| DNS, IPv6      | `2606:4700:4700::1113` and `2606:4700:4700::1003`  | [Add to AdGuard](adguard:add_dns_server?address=2606:4700:4700::1113&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2606:4700:4700::1113&name=) |
+| DNS, IPv4      | `1.1.1.3` and `1.0.0.3`                            | [Add to AdGuard](adguard:add_dns_server?address=1.1.1.3&name=Cloudflare%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=1.1.1.3&name=Cloudflare%20DNS) |
+| DNS, IPv6      | `2606:4700:4700::1113` and `2606:4700:4700::1003`  | [Add to AdGuard](adguard:add_dns_server?address=2606:4700:4700::1113&name=Cloudflare%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2606:4700:4700::1113&name=Cloudflare%20DNS) |
 | DNS-over-HTTPS, IPv4 | `https://family.cloudflare-dns.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://family.cloudflare-dns.com/dns-query&name=family.cloudflare-dns.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://family.cloudflare-dns.com/dns-query&name=family.cloudflare-dns.com) |
 | DNS-over-TLS | `tls://family.cloudflare-dns.com` | [Add to AdGuard](adguard:add_dns_server?address=tls://family.cloudflare-dns.com&name=family.cloudflare-dns.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://family.cloudflare-dns.com&name=family.cloudflare-dns.com) |
 
@@ -290,7 +291,7 @@ Blocks phishing, spam and malicious domains.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `8.26.56.26` and `8.20.247.20`                     | [Add to AdGuard](adguard:add_dns_server?address=8.26.56.26&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=8.26.56.26&name=) |
+| DNS, IPv4      | `8.26.56.26` and `8.20.247.20`                     | [Add to AdGuard](adguard:add_dns_server?address=8.26.56.26&name=Comodo%20Secure%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=8.26.56.26&name=Comodo%20Secure%20DNS) |
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.shield-2.dnsbycomodo.com` IP: `8.20.247.2`   | [Add to AdGuard](sdns://AQAAAAAAAAAACjguMjAuMjQ3LjIg0sJUqpYcHsoXmZb1X7yAHwg2xyN5q1J-zaiGG-Dgs7AoMi5kbnNjcnlwdC1jZXJ0LnNoaWVsZC0yLmRuc2J5Y29tb2RvLmNvbQ) |
 
 ### ControlD
@@ -301,38 +302,38 @@ Blocks phishing, spam and malicious domains.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `76.76.2.0` and `76.76.10.0`            | [Add to AdGuard](adguard:add_dns_server?address=76.76.2.1&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=76.76.2.1&name=) |
-| IPv6      | `2606:1a40::` and `2606:1a40:1::`            | [Add to AdGuard](adguard:add_dns_server?address=2606:1a40::&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2606:1a40::&name=) |
-| DNS-over-HTTPS | `https://freedns.controld.com/p0`          | [Add to AdGuard](adguard:add_dns_server?address=https://freedns.controld.com/p0&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://freedns.controld.com/p0&name=) |
-| DNS-over-TLS   | `p0.freedns.controld.com`           | [Add to AdGuard](adguard:add_dns_server?address=p0.freedns.controld.com&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=p0.freedns.controld.com&name=) |
+| DNS, IPv4      | `76.76.2.0` and `76.76.10.0`            | [Add to AdGuard](adguard:add_dns_server?address=76.76.2.0&name=ControlD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=76.76.2.0&name=ControlD) |
+| DNS, IPv6      | `2606:1a40::` and `2606:1a40:1::`            | [Add to AdGuard](adguard:add_dns_server?address=2606:1a40::&name=ControlD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2606:1a40::&name=ControlD) |
+| DNS-over-HTTPS | `https://freedns.controld.com/p0`          | [Add to AdGuard](adguard:add_dns_server?address=https://freedns.controld.com/p0&name=ControlD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://freedns.controld.com/p0&name=ControlD) |
+| DNS-over-TLS   | `tls://p0.freedns.controld.com`           | [Add to AdGuard](adguard:add_dns_server?address=tls://p0.freedns.controld.com&name=ControlD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://p0.freedns.controld.com&name=ControlD) |
 
 #### Block malware
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `76.76.2.1`             | [Add to AdGuard](adguard:add_dns_server?address=76.76.2.1&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=76.76.2.1&name=) |
-| DNS-over-HTTPS | `https://freedns.controld.com/p1`          | [Add to AdGuard](adguard:add_dns_server?address=https://freedns.controld.com/p1&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://freedns.controld.com/p1&name=) |
-| DNS-over-TLS   | `tls://p1.freedns.controld.com`           | [Add to AdGuard](adguard:add_dns_server?address=tls://p1.freedns.controld.com&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://p1.freedns.controld.com&name=) |
+| DNS, IPv4      | `76.76.2.1`             | [Add to AdGuard](adguard:add_dns_server?address=76.76.2.1&name=ControlD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=76.76.2.1&name=ControlD) |
+| DNS-over-HTTPS | `https://freedns.controld.com/p1`          | [Add to AdGuard](adguard:add_dns_server?address=https://freedns.controld.com/p1&name=ControlD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://freedns.controld.com/p1&name=ControlD) |
+| DNS-over-TLS   | `tls://p1.freedns.controld.com`           | [Add to AdGuard](adguard:add_dns_server?address=tls://p1.freedns.controld.com&name=ControlD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://p1.freedns.controld.com&name=ControlD) |
 
 #### Block malware + ads
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `76.76.2.2`             | [Add to AdGuard](adguard:add_dns_server?address=76.76.2.2&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=76.76.2.2&name=) |
-| DNS-over-HTTPS | `https://freedns.controld.com/p2`          | [Add to AdGuard](adguard:add_dns_server?address=https://freedns.controld.com/p2&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://freedns.controld.com/p2&name=) |
-| DNS-over-TLS   | `tls://p2.freedns.controld.com`           | [Add to AdGuard](adguard:add_dns_server?address=tls://p2.freedns.controld.com&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://p2.freedns.controld.com&name=) |
+| DNS, IPv4      | `76.76.2.2`             | [Add to AdGuard](adguard:add_dns_server?address=76.76.2.2&name=ControlD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=76.76.2.2&name=ControlD) |
+| DNS-over-HTTPS | `https://freedns.controld.com/p2`          | [Add to AdGuard](adguard:add_dns_server?address=https://freedns.controld.com/p2&name=ControlD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://freedns.controld.com/p2&name=ControlD) |
+| DNS-over-TLS   | `tls://p2.freedns.controld.com`           | [Add to AdGuard](adguard:add_dns_server?address=tls://p2.freedns.controld.com&name=ControlD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://p2.freedns.controld.com&name=ControlD) |
 
 #### Block malware + ads + social
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `76.76.2.3`             | [Add to AdGuard](adguard:add_dns_server?address=76.76.2.3&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=76.76.2.3&name=) |
-| DNS-over-HTTPS | `https://freedns.controld.com/p3`          | [Add to AdGuard](adguard:add_dns_server?address=https://freedns.controld.com/p3&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://freedns.controld.com/p3&name=) |
-| DNS-over-TLS   | `tls://p3.freedns.controld.com`           | [[Add to AdGuard](adguard:add_dns_server?address=tls://p3.freedns.controld.com&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://p3.freedns.controld.com&name=) |
+| DNS, IPv4      | `76.76.2.3`             | [Add to AdGuard](adguard:add_dns_server?address=76.76.2.3&name=ControlD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=76.76.2.3&name=ControlD) |
+| DNS-over-HTTPS | `https://freedns.controld.com/p3`          | [Add to AdGuard](adguard:add_dns_server?address=https://freedns.controld.com/p3&name=ControlD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://freedns.controld.com/p3&name=ControlD) |
+| DNS-over-TLS   | `tls://p3.freedns.controld.com`           | [Add to AdGuard](adguard:add_dns_server?address=tls://p3.freedns.controld.com&name=ControlD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://p3.freedns.controld.com&name=ControlD) |
 
 ### DeCloudUs DNS
 
-[DeCloudUs DNS](https://decloudus.com/) is a DNS service that lets you block anything you wish while by default protecting you and your family from ads, trackers, malware, phishing, malicious sites, and much more.
+[DeCloudUs DNS](https://decloudus.com/) is a DNS service that lets you block anything you wish while also protecting you and your family by default from ads, trackers, malware, phishing, malicious sites, and much more.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
@@ -384,19 +385,19 @@ These servers use some logging, self-signed certs or no support for strict mode.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `185.222.222.222` and `45.11.45.11`                | [Add to AdGuard](adguard:add_dns_server?address=185.222.222.222&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=185.222.222.222&name=) |
-| DNS, IPv6      | `2a09::` and `2a11::`                              | [Add to AdGuard](adguard:add_dns_server?address=2a09::&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a09::&name=) |
+| DNS, IPv4      | `185.222.222.222` and `45.11.45.11`                | [Add to AdGuard](adguard:add_dns_server?address=185.222.222.222&name=DNS.SB), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=185.222.222.222&name=DNS.SB) |
+| DNS, IPv6      | `2a09::` and `2a11::`                              | [Add to AdGuard](adguard:add_dns_server?address=2a09::&name=DNS.SB), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a09::&name=DNS.SB) |
 | DNS-over-HTTPS | `https://doh.dns.sb/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://doh.dns.sb/dns-query&name=doh.dns.sb), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh.dns.sb/dns-query&name=doh.dns.sb) |
 | DNS-over-TLS | `tls://dot.sb` | [Add to AdGuard](adguard:add_dns_server?address=tls://dot.sb&name=dot.sb), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dot.sb&name=dot.sb) |
 
 ### DNSPod Public DNS+
 
-[DNSPod Public DNS+](https://www.dnspod.cn/products/publicdns) is a privacy-friendly DNS provider with years of experience in domain name resolution services development, it aims to provide users more rapid, accurate and stable recursive resolution service.
+[DNSPod Public DNS+](https://www.dnspod.cn/products/publicdns) is a privacy-friendly DNS provider with years of experience in domain name resolution services development, it aims to provide users with more rapid, accurate and stable recursive resolution service.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `119.29.29.29`                   | [Add to AdGuard](adguard:add_dns_server?address=119.29.29.29&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=119.29.29.29&name=) |
-| DNS, IPv6      | `2402:4e00::`                   | [Add to AdGuard](adguard:add_dns_server?address=2402:4e00::&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2402:4e00::&name=) |
+| DNS, IPv4      | `119.29.29.29`                   | [Add to AdGuard](adguard:add_dns_server?address=119.29.29.29&name=DNSPod), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=119.29.29.29&name=DNSPod) |
+| DNS, IPv6      | `2402:4e00::`                   | [Add to AdGuard](adguard:add_dns_server?address=2402:4e00::&name=DNSPod), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2402:4e00::&name=DNSPod) |
 | DNS-over-HTTPS | `https://dns.pub/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.pub/dns-query&name=dns.pub), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.pub/dns-query&name=dns.pub) |
 | DNS-over-HTTPS | `https://sm2.doh.pub/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://sm2.doh.pub/dns-query&name=sm2.doh.pub), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://sm2.doh.pub/dns-query&name=sm2.dns.pub) |
 | DNS-over-TLS | `tls://dot.pub` | [Add to AdGuard](adguard:add_dns_server?address=tls://dot.pub&name=dot.pub), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dot.pub&name=dot.pub) |
@@ -407,7 +408,7 @@ These servers use some logging, self-signed certs or no support for strict mode.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `54.174.40.213` and `52.3.100.184`                 | [Add to AdGuard](adguard:add_dns_server?address=54.174.40.213&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=54.174.40.213&name=) |
+| DNS, IPv4      | `54.174.40.213` and `52.3.100.184`                 | [Add to AdGuard](adguard:add_dns_server?address=54.174.40.213&name=DNSWatchGO), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=54.174.40.213&name=DNSWatchGO) |
 
 ### Dyn DNS
 
@@ -415,7 +416,7 @@ These servers use some logging, self-signed certs or no support for strict mode.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `216.146.35.35` and `216.146.36.36`                | [Add to AdGuard](adguard:add_dns_server?address=216.146.35.35&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=216.146.35.35&name=) |
+| DNS, IPv4      | `216.146.35.35` and `216.146.36.36`                | [Add to AdGuard](adguard:add_dns_server?address=216.146.35.35&name=Dyn%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=216.146.35.35&name=Dyn%20DNS) |
 
 ### Freenom World
 
@@ -423,7 +424,7 @@ These servers use some logging, self-signed certs or no support for strict mode.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `80.80.80.80` and `80.80.81.81`                    | [Add to AdGuard](adguard:add_dns_server?address=80.80.80.80&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=80.80.80.80&name=) |
+| DNS, IPv4      | `80.80.80.80` and `80.80.81.81`                    | [Add to AdGuard](adguard:add_dns_server?address=80.80.80.80&name=Freenom%20World), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=80.80.80.80&name=Freenom%20World) |
 
 ### Google DNS
 
@@ -431,8 +432,8 @@ These servers use some logging, self-signed certs or no support for strict mode.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `8.8.8.8` and `8.8.4.4`                            | [Add to AdGuard](adguard:add_dns_server?address=8.8.8.8&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=8.8.8.8&name=) |
-| DNS, IPv6      | `2001:4860:4860::8888` and `2001:4860:4860::8844`  | [Add to AdGuard](adguard:add_dns_server?address=2001:4860:4860::8888&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:4860:4860::8888&name=) |
+| DNS, IPv4      | `8.8.8.8` and `8.8.4.4`                            | [Add to AdGuard](adguard:add_dns_server?address=8.8.8.8&name=Google%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=8.8.8.8&name=Google%20DNS) |
+| DNS, IPv6      | `2001:4860:4860::8888` and `2001:4860:4860::8844`  | [Add to AdGuard](adguard:add_dns_server?address=2001:4860:4860::8888&name=Google%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:4860:4860::8888&name=Google%20DNS) |
 | DNS-over-HTTPS | `https://dns.google/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.google/dns-query&name=dns.google), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.google/dns-query&name=dns.google) |
 | DNS-over-TLS | `tls://dns.google` | [Add to AdGuard](adguard:add_dns_server?address=tls://dns.google&name=dns.google), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dns.google&name=dns.google) |
 
@@ -442,8 +443,8 @@ Hurricane Electric Public Recursor is a free alternative DNS service by Hurrican
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `74.82.42.42` | [Add to AdGuard](adguard:add_dns_server?address=74.82.42.42&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=74.82.42.42&name=) |
-| DNS, IPv6 | `2001:470:20::2` | [Add to AdGuard](adguard:add_dns_server?address=2001:470:20::2&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:470:20::2&name=) |
+| DNS, IPv4 | `74.82.42.42` | [Add to AdGuard](adguard:add_dns_server?address=74.82.42.42&name=Hurricane%20Electric), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=74.82.42.42&name=Hurricane%20Electric) |
+| DNS, IPv6 | `2001:470:20::2` | [Add to AdGuard](adguard:add_dns_server?address=2001:470:20::2&name=Hurricane%20Electric), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:470:20::2&name=Hurricane%20Electric) |
 | DNS-over-HTTPS | `https://ordns.he.net/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://ordns.he.net/dns-query&name=ordns.he.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://ordns.he.net/dns-query&name=ordns.he.net) |
 | DNS-over-TLS | `tls://ordns.he.net` | [Add to AdGuard](adguard:add_dns_server?address=tls://ordns.he.net&name=ordns.he.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://ordns.he.net&name=ordns.he.net) |
 
@@ -495,11 +496,11 @@ Hurricane Electric Public Recursor is a free alternative DNS service by Hurrican
 
 ### Nawala Childprotection DNS
 
-[Nawala Childprotection DNS](http://nawala.id/) is an anycast Internet filtering system that protects children from inappropriate websites and abusive contents.
+[Nawala Childprotection DNS](http://nawala.id/) is an anycast Internet filtering system that protects children from inappropriate websites and abusive content.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `180.131.144.144` and `180.131.145.145`            | [Add to AdGuard](adguard:add_dns_server?address=180.131.144.144&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=180.131.144.144&name=) |
+| DNS, IPv4      | `180.131.144.144` and `180.131.145.145`            | [Add to AdGuard](adguard:add_dns_server?address=180.131.144.144&name=Nawala), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=180.131.144.144&name=Nawala) |
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.nawala.id` IP: `180.131.144.144`  | [Add to AdGuard](sdns://AQAAAAAAAAAADzE4MC4xMzEuMTQ0LjE0NCDGC-b_38Dj4-ikI477AO1GXcLPfETOFpE36KZIHdOzLhkyLmRuc2NyeXB0LWNlcnQubmF3YWxhLmlk) |
 
 ### Neustar Recursive DNS
@@ -512,8 +513,8 @@ These servers provide reliable and fast DNS lookups without blocking any specifi
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `156.154.70.1` and `156.154.71.1`                  | [Add to AdGuard](adguard:add_dns_server?address=156.154.70.1&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=156.154.70.1&name=) |
-| DNS, IPv6      | `2610:a1:1018::1` and `2610:a1:1019::1`            | [Add to AdGuard](adguard:add_dns_server?address=2610:a1:1018::1&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2610:a1:1018::1&name=) |
+| DNS, IPv4      | `156.154.70.1` and `156.154.71.1`                  | [Add to AdGuard](adguard:add_dns_server?address=156.154.70.1&name=Neustar), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=156.154.70.1&name=Neustar) |
+| DNS, IPv6      | `2610:a1:1018::1` and `2610:a1:1019::1`            | [Add to AdGuard](adguard:add_dns_server?address=2610:a1:1018::1&name=Neustar), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2610:a1:1018::1&name=Neustar) |
 
 #### Reliability & Performance 2
 
@@ -521,8 +522,8 @@ These servers provide reliable and fast DNS lookups without blocking any specifi
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `156.154.70.5` and `156.154.71.5`                  | [Add to AdGuard](adguard:add_dns_server?address=156.154.70.5&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=156.154.70.5&name=) |
-| DNS, IPv6      | `2610:a1:1018::5` and `2610:a1:1019::5`            | [Add to AdGuard](adguard:add_dns_server?address=2610:a1:1018::5&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2610:a1:1018::5&name=) |
+| DNS, IPv4      | `156.154.70.5` and `156.154.71.5`                  | [Add to AdGuard](adguard:add_dns_server?address=156.154.70.5&name=Neustar), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=156.154.70.5&name=Neustar) |
+| DNS, IPv6      | `2610:a1:1018::5` and `2610:a1:1019::5`            | [Add to AdGuard](adguard:add_dns_server?address=2610:a1:1018::5&name=Neustar), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2610:a1:1018::5&name=Neustar) |
 
 #### Threat Protection
 
@@ -530,8 +531,8 @@ These servers provide protection against malicious domains and also include *Rel
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `156.154.70.2` and `156.154.71.2`                  | [Add to AdGuard](adguard:add_dns_server?address=156.154.70.2&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=156.154.70.2&name=) |
-| DNS, IPv6      | `2610:a1:1018::2` and `2610:a1:1019::2`            | [Add to AdGuard](adguard:add_dns_server?address=2610:a1:1018::2&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2610:a1:1018::2&name=) |
+| DNS, IPv4      | `156.154.70.2` and `156.154.71.2`                  | [Add to AdGuard](adguard:add_dns_server?address=156.154.70.2&name=Neustar), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=156.154.70.2&name=Neustar) |
+| DNS, IPv6      | `2610:a1:1018::2` and `2610:a1:1019::2`            | [Add to AdGuard](adguard:add_dns_server?address=2610:a1:1018::2&name=Neustar), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2610:a1:1018::2&name=Neustar) |
 
 #### Family Secure
 
@@ -539,8 +540,8 @@ These servers provide adult content blocking and also include *Reliability & Per
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `156.154.70.3` and `156.154.71.3`                  | [Add to AdGuard](adguard:add_dns_server?address=156.154.70.3&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=156.154.70.3&name=) |
-| DNS, IPv6      | `2610:a1:1018::3` and `2610:a1:1019::3`            | [Add to AdGuard](adguard:add_dns_server?address=2610:a1:1018::3&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2610:a1:1018::3&name=) |
+| DNS, IPv4      | `156.154.70.3` and `156.154.71.3`                  | [Add to AdGuard](adguard:add_dns_server?address=156.154.70.3&name=Neustar), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=156.154.70.3&name=Neustar) |
+| DNS, IPv6      | `2610:a1:1018::3` and `2610:a1:1019::3`            | [Add to AdGuard](adguard:add_dns_server?address=2610:a1:1018::3&name=Neustar), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2610:a1:1018::3&name=Neustar) |
 
 #### Business Secure
 
@@ -548,8 +549,8 @@ These servers provide blocking unwanted and time-wasting content and also includ
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `156.154.70.4` and `156.154.71.4`                  | [Add to AdGuard](adguard:add_dns_server?address=156.154.70.4&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=156.154.70.4&name=) |
-| DNS, IPv6      | `2610:a1:1018::4` and `2610:a1:1019::4`            | [Add to AdGuard](adguard:add_dns_server?address=2610:a1:1018::4&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2610:a1:1018::4&name=) |
+| DNS, IPv4      | `156.154.70.4` and `156.154.71.4`                  | [Add to AdGuard](adguard:add_dns_server?address=156.154.70.4&name=Neustar), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=156.154.70.4&name=Neustar) |
+| DNS, IPv6      | `2610:a1:1018::4` and `2610:a1:1019::4`            | [Add to AdGuard](adguard:add_dns_server?address=2610:a1:1018::4&name=Neustar), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2610:a1:1018::4&name=Neustar) |
 
 ### NextDNS
 
@@ -579,8 +580,8 @@ Recommended for most users, very flexible filtering with blocking most ads netwo
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-|DNS-over-HTTPS|`https://ada.openbld.net/dns-query`|[Add to AdGuard](sdns://AgAAAAAAAAAAAAAPYWRhLm9wZW5ibGQubmV0Ci9kbnMtcXVlcnk)|
-|DNS-over-TLS|`tls://ada.openbld.net`|[Add to AdGuard](sdns://AwAAAAAAAAAAAAAPYWRhLm9wZW5ibGQubmV0)|
+|DNS-over-HTTPS|`https://ada.openbld.net/dns-query`|[Add to AdGuard](sdns://AgAAAAAAAAAAAAAPYWRhLm9wZW5ibGQubmV0Ci9kbnMtcXVlcnk), [Add to AdGuard](adguard:add_dns_server?address=https://ada.openbld.net/dns-query&name=ada.openbld.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://ada.openbld.net/dns-query&name=ada.openbld.net)|
+|DNS-over-TLS|`tls://ada.openbld.net`|[Add to AdGuard](sdns://AwAAAAAAAAAAAAAPYWRhLm9wZW5ibGQubmV0), [Add to AdGuard](adguard:add_dns_server?address=tls://ada.openbld.net&name=ada.openbld.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://ada.openbld.net&name=ada.openbld.net)|
 
 #### Strict Filtering (RIC)
 
@@ -588,8 +589,8 @@ More strictly filtering policies with blocking — ads, marketing, tracking, cli
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-|DNS-over-HTTPS|`https://ric.openbld.net/dns-query`|[Add to AdGuard](sdns://AgAAAAAAAAAAAAAPcmljLm9wZW5ibGQubmV0Ci9kbnMtcXVlcnk)|
-|DNS-over-TLS|`tls://ric.openbld.net`|[Add to AdGuard](sdns://AwAAAAAAAAAAAAAPcmljLm9wZW5ibGQubmV0)|
+|DNS-over-HTTPS|`https://ric.openbld.net/dns-query`|[Add to AdGuard](sdns://AgAAAAAAAAAAAAAPcmljLm9wZW5ibGQubmV0Ci9kbnMtcXVlcnk), [Add to AdGuard](adguard:add_dns_server?address=https://ric.openbld.net/dns-query&name=ric.openbld.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://ric.openbld.net/dns-query&name=ric.openbld.net)|
+|DNS-over-TLS|`tls://ric.openbld.net`|[Add to AdGuard](sdns://AwAAAAAAAAAAAAAPcmljLm9wZW5ibGQubmV0), [Add to AdGuard](adguard:add_dns_server?address=tls://ric.openbld.net&name=ric.openbld.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://ric.openbld.net&name=ric.openbld.net)|
 
 ### Quad9 DNS
 
@@ -601,8 +602,8 @@ Regular DNS servers which provide protection from phishing and spyware. They inc
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `9.9.9.9` and `149.112.112.112`                    | [Add to AdGuard](adguard:add_dns_server?address=9.9.9.9&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=9.9.9.9&name=) |
-| DNS, IPv6      | `2620:fe::fe` and `2620:fe::9`                  | [Add to AdGuard](adguard:add_dns_server?address=2620:fe::fe&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2620:fe::fe&name=) |
+| DNS, IPv4      | `9.9.9.9` and `149.112.112.112`                    | [Add to AdGuard](adguard:add_dns_server?address=9.9.9.9&name=Quad9), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=9.9.9.9&name=Quad9) |
+| DNS, IPv6      | `2620:fe::fe` and `2620:fe::9`                  | [Add to AdGuard](adguard:add_dns_server?address=2620:fe::fe&name=Quad9), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2620:fe::fe&name=Quad9) |
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.quad9.net` IP: `9.9.9.9:8443`| [Add to AdGuard](sdns://AQMAAAAAAAAADDkuOS45Ljk6ODQ0MyBnyEe4yHWM0SAkVUO-dWdG3zTfHYTAC4xHA2jfgh2GPhkyLmRuc2NyeXB0LWNlcnQucXVhZDkubmV0) |
 | DNSCrypt, IPv6 |  Provider: `2.dnscrypt-cert.quad9.net` IP: `[2620:fe::fe]:8443`  | [Add to AdGuard](sdns://AQMAAAAAAAAAElsyNjIwOmZlOjpmZV06ODQ0MyBnyEe4yHWM0SAkVUO-dWdG3zTfHYTAC4xHA2jfgh2GPhkyLmRuc2NyeXB0LWNlcnQucXVhZDkubmV0) |
 | DNS-over-HTTPS | `https://dns.quad9.net/dns-query`  | [Add to AdGuard](adguard:add_dns_server?address=https://dns.quad9.net/dns-query&name=dns.quad9.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.quad9.net/dns-query&name=dns.quad9.net) |
@@ -614,8 +615,8 @@ Unsecured DNS servers don’t provide security blocklists, DNSSEC, or EDNS Clien
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `9.9.9.10` and `149.112.112.10`                    | [Add to AdGuard](adguard:add_dns_server?address=9.9.9.10&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=9.9.9.100&name=) |
-| DNS, IPv6      | `2620:fe::10` IP: `2620:fe::fe:10`                               | [Add to AdGuard](adguard:add_dns_server?address=2620:fe::10&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2620:fe::10&name=) |
+| DNS, IPv4      | `9.9.9.10` and `149.112.112.10`                    | [Add to AdGuard](adguard:add_dns_server?address=9.9.9.10&name=Quad9), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=149.112.112.10&name=Quad9) |
+| DNS, IPv6      | `2620:fe::10` IP: `2620:fe::fe:10`                               | [Add to AdGuard](adguard:add_dns_server?address=2620:fe::10&name=Quad9), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2620:fe::10&name=Quad9) |
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.quad9.net` IP: `9.9.9.10:8443`  | [Add to AdGuard](sdns://AQMAAAAAAAAADTkuOS45LjEwOjg0NDMgZ8hHuMh1jNEgJFVDvnVnRt803x2EwAuMRwNo34Idhj4ZMi5kbnNjcnlwdC1jZXJ0LnF1YWQ5Lm5ldA) |
 | DNSCrypt, IPv6 |  Provider: `2.dnscrypt-cert.quad9.net` IP: `[2620:fe::fe:10]:8443`  | [Add to AdGuard](sdns://AQMAAAAAAAAAFVsyNjIwOmZlOjpmZToxMF06ODQ0MyBnyEe4yHWM0SAkVUO-dWdG3zTfHYTAC4xHA2jfgh2GPhkyLmRuc2NyeXB0LWNlcnQucXVhZDkubmV0) |
 | DNS-over-HTTPS | `https://dns10.quad9.net/dns-query`  | [Add to AdGuard](adguard:add_dns_server?address=https://dns10.quad9.net/dns-query&name=dns10.quad9.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns10.quad9.net/dns-query&name=dns10.quad9.net) |
@@ -627,43 +628,12 @@ EDNS Client Subnet is a method that includes components of end-user IP address d
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `9.9.9.11` and `149.112.112.11`                    | [Add to AdGuard](adguard:add_dns_server?address=9.9.9.11&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=9.9.9.11&name=) |
-| DNS, IPv6      | `2620:fe::11` IP: `2620:fe::fe:11`                 | [Add to AdGuard](adguard:add_dns_server?address=2620:fe::11&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2620:fe::11&name=) |
+| DNS, IPv4      | `9.9.9.11` and `149.112.112.11`                    | [Add to AdGuard](adguard:add_dns_server?address=9.9.9.11&name=Quad9), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=9.9.9.11&name=Quad9) |
+| DNS, IPv6      | `2620:fe::11` IP: `2620:fe::fe:11`                 | [Add to AdGuard](adguard:add_dns_server?address=2620:fe::11&name=Quad9), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2620:fe::11&name=Quad9) |
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.quad9.net` IP: `9.9.9.11:8443`  | [Add to AdGuard](sdns://AQMAAAAAAAAADTkuOS45LjExOjg0NDMgZ8hHuMh1jNEgJFVDvnVnRt803x2EwAuMRwNo34Idhj4ZMi5kbnNjcnlwdC1jZXJ0LnF1YWQ5Lm5ldA) |
 | DNSCrypt, IPv6 |  Provider: `2.dnscrypt-cert.quad9.net` IP: `[2620:fe::11]:8443`  | [Add to AdGuard](sdns://AQMAAAAAAAAAElsyNjIwOmZlOjoxMV06ODQ0MyBnyEe4yHWM0SAkVUO-dWdG3zTfHYTAC4xHA2jfgh2GPhkyLmRuc2NyeXB0LWNlcnQucXVhZDkubmV0) |
 | DNS-over-HTTPS | `https://dns11.quad9.net/dns-query`   | [Add to AdGuard](adguard:add_dns_server?address=https://dns11.quad9.net/dns-query&name=dns11.quad9.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns11.quad9.net/dns-query&name=dns11.quad9.net) |
 | DNS-over-TLS   | `tls://dns11.quad9.net`       | [Add to AdGuard](adguard:add_dns_server?address=tls://dns11.quad9.net&name=dns11.quad9.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dns11.quad9.net&name=dns11.quad9.net) |
-
-### Quadrant Security
-
-[Quadrant Security](https://www.quadrantsec.com/post/public-dns-resolver-with-tls-https-support) offers DoH and DoT servers for the general public with no logging or filtering.
-
-| Protocol       | Address                                            |                |
-|----------------|----------------------------------------------------|----------------|
-|DNS-over-HTTPS|`https://doh.qis.io/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://doh.qis.io/dns-query&name=doh.qis.io), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh.qis.io/dns-query&name=doh.qis.io) |
-|DNS-over-TLS|`tls://dns-tls.qis.io` | [Add to AdGuard](adguard:add_dns_server?address=tls://dns-tls.qis.io&name=dns-tls.qis.io), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dns-tls.qis.io&name=dns-tls.qis.io) |
-
-### Rabbit DNS
-
-[Rabbit DNS](https://rabbitdns.org/) is a privacy-focused DoH service that doesn’t collect any user data.
-
-#### Non-filtering
-
-| Protocol       | Address                                            |                |
-|----------------|----------------------------------------------------|----------------|
-|DNS-over-HTTPS|`https://dns.rabbitdns.org/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.rabbitdns.org/dns-query&name=dns.rabbitdns.org), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.rabbitdns.org/dns-query&name=dns.rabbitdns.org) |
-
-#### Security-filtering
-
-| Protocol       | Address                                            |                |
-|----------------|----------------------------------------------------|----------------|
-|DNS-over-HTTPS|`https://security.rabbitdns.org/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://security.rabbitdns.org/dns-query&name=security.rabbitdns.org), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://security.rabbitdns.org/dns-query&name=security.rabbitdns.org) |
-
-#### Family-filtering
-
-| Protocol       | Address                                            |                |
-|----------------|----------------------------------------------------|----------------|
-|DNS-over-HTTPS|`https://family.rabbitdns.org/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://family.rabbitdns.org/dns-query&name=family.rabbitdns.org), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://family.rabbitdns.org/dns-query&name=family.rabbitdns.org) |
 
 ### RethinkDNS
 
@@ -682,7 +652,7 @@ EDNS Client Subnet is a method that includes components of end-user IP address d
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `195.46.39.39` and `195.46.39.40`                  | [Add to AdGuard](adguard:add_dns_server?address=195.46.39.39&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=195.46.39.39&name=) |
+| DNS, IPv4      | `195.46.39.39` and `195.46.39.40`                  | [Add to AdGuard](adguard:add_dns_server?address=195.46.39.39&name=Safe%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=195.46.39.39&name=Safe%20DNS) |
 
 ### Safe Surfer
 
@@ -690,19 +660,8 @@ EDNS Client Subnet is a method that includes components of end-user IP address d
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `104.155.237.225` and `104.197.28.121`             | [Add to AdGuard](adguard:add_dns_server?address=104.155.237.225&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=104.155.237.225&name=) |
+| DNS, IPv4      | `104.155.237.225` and `104.197.28.121`             | [Add to AdGuard](adguard:add_dns_server?address=104.155.237.225&name=Safe%20Surfer), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=104.155.237.225&name=Safe%20Surfer) |
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.safesurfer.co.nz` IP: `104.197.28.121`| [Add to AdGuard](sdns://AQMAAAAAAAAADjEwNC4xOTcuMjguMTIxICcgf9USBOg2e0g0AF35_9HTC74qnDNjnm7b-K7ZHUDYIDIuZG5zY3J5cHQtY2VydC5zYWZlc3VyZmVyLmNvLm56) |
-
-### 360 Secure DNS
-
-**360 Secure DNS** is a industry-leading recursive DNS service with advanced network security threat protection.
-
-| Protocol       | Address                                            |                |
-|----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `101.226.4.6` and `218.30.118.6`                   | [Add to AdGuard](adguard:add_dns_server?address=101.226.4.6&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=101.226.4.6&name=) |
-| DNS, IPv4      | `123.125.81.6` and `140.207.198.6`                 | [Add to AdGuard](adguard:add_dns_server?address=123.125.81.6&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=123.125.81.6&name=) |
-| DNS-over-HTTPS | `https://doh.360.cn/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://doh.360.cn/dns-query&name=doh.360.cn), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh.360.cn/dns-query&name=doh.360.cn) |
-| DNS-over-TLS | `tls://dot.360.cn` | [Add to AdGuard](adguard:add_dns_server?address=tls://dot.360.cn&name=dot.360.cn), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dot.360.cn&name=dot.360.cn) |
 
 ### Surfshark DNS
 
@@ -710,20 +669,11 @@ EDNS Client Subnet is a method that includes components of end-user IP address d
 
 | Protocol       | Address                                  |                |
 |----------------|------------------------------------------|----------------|
-| DNS, IPv4      | `194.169.169.169`                        | [Add to AdGuard](adguard:add_dns_server?address=194.169.169.169&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=194.169.169.169&name=) |
-| DNS, IPv6      | `2a09:a707:169::`                        | [Add to AdGuard](adguard:add_dns_server?address=2a09:a707:169::&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a09:a707:169::&name=) |
+| DNS, IPv4      | `194.169.169.169`                        | [Add to AdGuard](adguard:add_dns_server?address=194.169.169.169&name=Surfshark%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=194.169.169.169&name=Surfshark%20DNS) |
+| DNS, IPv6      | `2a09:a707:169::`                        | [Add to AdGuard](adguard:add_dns_server?address=2a09:a707:169::&name=Surfshark%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a09:a707:169::&name=Surfshark%20DNS) |
 | DNS-over-HTTPS | `https://dns.surfsharkdns.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.surfsharkdns.com/dns-query&name=dns.surfsharkdns.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.surfsharkdns.com/dns-query&name=dns.surfsharkdns.com) |
 | DNS-over-TLS   | `tls://dns.surfsharkdns.com`             | [Add to AdGuard](adguard:add_dns_server?address=tls://dns.surfsharkdns.com&name=dns.surfsharkdns.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dns.surfsharkdns.com&name=dns.surfsharkdns.com) |
 | DNS-over-QUIC  | `quic://dns.surfsharkdns.com`            | [Add to AdGuard](adguard:add_dns_server?address=quic://dns.surfsharkdns.com&name=dns.surfsharkdns.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=quic://dns.surfsharkdns.com&name=dns.surfsharkdns.com) |
-
-### Verisign Public DNS
-
-[Verisign Public DNS](https://www.verisign.com/security-services/public-dns/) is a free DNS service that offers improved DNS stability and security over other alternatives. Verisign respects users’ privacy: they neither sell public DNS data to third parties nor redirect users’ queries to serve them ads.
-
-| Protocol       | Address                                            |                |
-|----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `64.6.64.6` and `64.6.65.6`                        | [Add to AdGuard](adguard:add_dns_server?address=64.6.64.6&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=64.6.64.6&name=) |
-| DNS, IPv6      | `2620:74:1b::1:1` and `2620:74:1c::2:2`            | [Add to AdGuard](adguard:add_dns_server?address=2620:74:1b::1:1&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2620:74:1b::1:1&name=) |
 
 ### v.recipes DNS (former 0ms.dev)
 
@@ -731,12 +681,21 @@ EDNS Client Subnet is a method that includes components of end-user IP address d
 
 It is designed with various optimizations, such as HTTP/3, caching, and more.
 It leverages machine learning to protect users from potential security threats while also optimizing itself over time.
-Some of its users did see how the DNS handles queries in real-time from its statistics page, but currently the stats page is temporarily disabled.
-Even if the stats page is temporarily disabled, the DNS itself still able to serve users’ requests normally.
+Some of its users can see how the DNS handles queries in real-time from its statistics page, but currently the stats page is temporarily disabled.
+Even if the stats page is temporarily disabled, the DNS itself still able to serve users' requests normally.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
 | DNS-over-HTTPS | `https://v.recipes/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://v.recipes/dns-query&name=v.recipes), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://v.recipes/dns-query&name=v.recipes) |
+
+### Verisign Public DNS
+
+[Verisign Public DNS](https://www.verisign.com/security-services/public-dns/) is a free DNS service that offers improved DNS stability and security over other alternatives. Verisign respects users' privacy: they neither sell public DNS data to third parties nor redirect users' queries to serve them ads.
+
+| Protocol       | Address                                            |                |
+|----------------|----------------------------------------------------|----------------|
+| DNS, IPv4      | `64.6.64.6` and `64.6.65.6`                        | [Add to AdGuard](adguard:add_dns_server?address=64.6.64.6&name=Verisign), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=64.6.64.6&name=Verisign) |
+| DNS, IPv6      | `2620:74:1b::1:1` and `2620:74:1c::2:2`            | [Add to AdGuard](adguard:add_dns_server?address=2620:74:1b::1:1&name=Verisign), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2620:74:1b::1:1&name=Verisign) |
 
 ### Wikimedia DNS
 
@@ -751,6 +710,34 @@ Even if the stats page is temporarily disabled, the DNS itself still able to ser
 
 Regional DNS resolvers are typically focused on specific geographic regions, offering optimized performance for users in those areas. These resolvers are often operated by non-profit organizations, local ISPs, or other entities.
 
+### 114DNS
+
+[114DNS](https://www.114dns.com) is a professional and high-reliability DNS service.
+
+#### Normal
+
+Block ads and annoying websites.
+
+| Protocol | Address | |
+|----------------|----------------------------------------------------|----------------|
+| DNS, IPv4 | `114.114.114.114` and `114.114.115.115` | [Add to AdGuard](adguard:add_dns_server?address=114.114.114.114&name=114DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=114.114.114.114&name=114DNS) |
+
+#### Safe
+
+Blocks phishing, malicious and other unsafe websites.
+
+| Protocol | Address | |
+|----------------|----------------------------------------------------|----------------|
+| DNS, IPv4 | `114.114.114.119` and `114.114.115.119` | [Add to AdGuard](adguard:add_dns_server?address=114.114.114.119&name=114DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=114.114.114.119&name=114DNS) |
+
+#### Family
+
+These servers block adult websites and inappropriate contents.
+
+| Protocol | Address | |
+|----------------|----------------------------------------------------|----------------|
+| DNS, IPv4 | `114.114.114.110` and `114.114.115.110` | [Add to AdGuard](adguard:add_dns_server?address=114.114.114.110&name=114DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=114.114.114.110&name=114DNS) |
+
 ### Applied Privacy DNS
 
 [Applied Privacy DNS](https://applied-privacy.net/) operates DNS privacy services to help protect DNS traffic and to help diversify the DNS resolver landscape offering modern protocols.
@@ -762,11 +749,11 @@ Regional DNS resolvers are typically focused on specific geographic regions, off
 
 ### ByteDance Public DNS
 
-ByteDance Public DNS is a free alternative DNS service by ByteDance at China. The only DNS currently provided by ByteDance supports IPV4. DOH, DOT, DOQ, and other encrypted DNS services will be launched soon.
+ByteDance Public DNS is a free alternative DNS service by ByteDance at China. The only DNS currently provided by ByteDance supports IPv4. DOH, DOT, DOQ, and other encrypted DNS services will be launched soon.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4      | `180.184.1.1` and `180.184.2.2`                  | [Add to AdGuard](adguard:add_dns_server?address=180.184.1.1&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=180.184.1.1&name=) |
+| DNS, IPv4      | `180.184.1.1` and `180.184.2.2`                  | [Add to AdGuard](adguard:add_dns_server?address=180.184.1.1&name=ByteDance), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=180.184.1.1&name=ByteDance) |
 
 ### CERT-EE
 
@@ -787,8 +774,8 @@ In *Private* mode, DNS resolution only.
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `149.112.121.10` and `149.112.122.10` | [Add to AdGuard](adguard:add_dns_server?address=149.112.121.10&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=149.112.121.10&name=) |
-| DNS, IPv6 | `2620:10A:80BB::10` and `2620:10A:80BC::10` | [Add to AdGuard](adguard:add_dns_server?address=2620:10A:80BB::10&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2620:10A:80BB::10&name=) |
+| DNS, IPv4 | `149.112.121.10` and `149.112.122.10` | [Add to AdGuard](adguard:add_dns_server?address=149.112.121.10&name=CIRA%20Canadian%20Shield), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=149.112.121.10&name=CIRA%20Canadian%20Shield) |
+| DNS, IPv6 | `2620:10A:80BB::10` and `2620:10A:80BC::10` | [Add to AdGuard](adguard:add_dns_server?address=2620:10A:80BB::10&name=CIRA%20Canadian%20Shield), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2620:10A:80BB::10&name=CIRA%20Canadian%20Shield) |
 | DNS-over-HTTPS | `https://private.canadianshield.cira.ca/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://private.canadianshield.cira.ca/dns-query&name=private.canadianshield.cira.ca), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://private.canadianshield.cira.ca/dns-query&name=private.canadianshield.cira.ca) |
 | DNS-over-TLS — Private | Hostname: `tls://private.canadianshield.cira.ca` IP: `149.112.121.10` and IPv6: `2620:10A:80BB::10` | [Add to AdGuard](adguard:add_dns_server?address=tls://private.canadianshield.cira.ca&name=private.canadianshield.cira.ca), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://private.canadianshield.cira.ca&name=private.canadianshield.cira.ca) |
 
@@ -798,8 +785,8 @@ In *Protected* mode, malware and phishing protection.
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `149.112.121.20` and `149.112.122.20` | [Add to AdGuard](adguard:add_dns_server?address=149.112.121.20&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=149.112.121.20&name=) |
-| DNS, IPv6 | `2620:10A:80BB::20` and `2620:10A:80BC::20` | [Add to AdGuard](adguard:add_dns_server?address=2620:10A:80BB::20&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2620:10A:80BB::20&name=) |
+| DNS, IPv4 | `149.112.121.20` and `149.112.122.20` | [Add to AdGuard](adguard:add_dns_server?address=149.112.121.20&name=CIRA%20Canadian%20Shield), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=149.112.121.20&name=CIRA%20Canadian%20Shield) |
+| DNS, IPv6 | `2620:10A:80BB::20` and `2620:10A:80BC::20` | [Add to AdGuard](adguard:add_dns_server?address=2620:10A:80BB::20&name=CIRA%20Canadian%20Shield), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2620:10A:80BB::20&name=CIRA%20Canadian%20Shield) |
 | DNS-over-HTTPS | `https://protected.canadianshield.cira.ca/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://protected.canadianshield.cira.ca/dns-query&name=protected.canadianshield.cira.ca), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://protected.canadianshield.cira.ca/dns-query&name=protected.canadianshield.cira.ca) |
 | DNS-over-TLS — Protected | Hostname: `tls://protected.canadianshield.cira.ca` IP: `149.112.121.20` and IPv6: `2620:10A:80BB::20` | [Add to AdGuard](adguard:add_dns_server?address=tls://protected.canadianshield.cira.ca&name=protected.canadianshield.cira.ca), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://protected.canadianshield.cira.ca&name=protected.canadianshield.cira.ca) |
 
@@ -809,8 +796,8 @@ In *Family* mode, *Protected* + blocking adult content.
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `149.112.121.30` and `149.112.122.30` | [Add to AdGuard](adguard:add_dns_server?address=149.112.121.30&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=149.112.121.30&name=) |
-| DNS, IPv6 | `2620:10A:80BB::30` and `2620:10A:80BC::30` | [Add to AdGuard](adguard:add_dns_server?address=2620:10A:80BB::30&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2620:10A:80BB::30&name=) |
+| DNS, IPv4 | `149.112.121.30` and `149.112.122.30` | [Add to AdGuard](adguard:add_dns_server?address=149.112.121.30&name=CIRA%20Canadian%20Shield), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=149.112.121.30&name=CIRA%20Canadian%20Shield) |
+| DNS, IPv6 | `2620:10A:80BB::30` and `2620:10A:80BC::30` | [Add to AdGuard](adguard:add_dns_server?address=2620:10A:80BB::30&name=CIRA%20Canadian%20Shield), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2620:10A:80BB::30&name=CIRA%20Canadian%20Shield) |
 | DNS-over-HTTPS | `https://family.canadianshield.cira.ca/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://family.canadianshield.cira.ca/dns-query&name=family.canadianshield.cira.ca), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://family.canadianshield.cira.ca/dns-query&name=family.canadianshield.cira.ca) |
 | DNS-over-TLS — Family | Hostname: `tls://family.canadianshield.cira.ca` IP: `149.112.121.30` and IPv6: `2620:10A:80BB::30` | [Add to AdGuard](adguard:add_dns_server?address=tls://family.canadianshield.cira.ca&name=family.canadianshield.cira.ca), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://family.canadianshield.cira.ca&name=family.canadianshield.cira.ca) |
 
@@ -842,12 +829,12 @@ Access to AI, blocking of ads, counters, phishing and malicious websites.
 
 ### CZ.NIC ODVR
 
-[CZ.NIC ODVR](https://www.nic.cz/odvr/) CZ.NIC ODVR are Open DNSSEC Validating Resolvers. CZ.NIC neither collect any personal data nor gather information on pages where devices sends personal data.
+[CZ.NIC ODVR](https://www.nic.cz/odvr/) CZ.NIC ODVR is an Open DNSSEC Validating Resolver. CZ.NIC neither collect any personal data nor gather information on pages where devices sends personal data.
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `193.17.47.1` and `185.43.135.1` | [Add to AdGuard](adguard:add_dns_server?address=193.17.47.1&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=193.17.47.1&name=) |
-| DNS, IPv6 | `2001:148f:ffff::1` and `2001:148f:fffe::1` | [Add to AdGuard](adguard:add_dns_server?address=2001:148f:ffff::1&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:148f:ffff::1&name=) |
+| DNS, IPv4 | `193.17.47.1` and `185.43.135.1` | [Add to AdGuard](adguard:add_dns_server?address=193.17.47.1&name=CZ.NIC%20ODVR), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=193.17.47.1&name=CZ.NIC%20ODVR) |
+| DNS, IPv6 | `2001:148f:ffff::1` and `2001:148f:fffe::1` | [Add to AdGuard](adguard:add_dns_server?address=2001:148f:ffff::1&name=CZ.NIC%20ODVR), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:148f:ffff::1&name=CZ.NIC%20ODVR) |
 | DNS-over-HTTPS | `https://odvr.nic.cz/doh` | [Add to AdGuard](adguard:add_dns_server?address=https://odvr.nic.cz/doh&name=odvr.nic.cz), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://odvr.nic.cz/doh&name=odvr.nic.cz) |
 | DNS-over-TLS | `tls://odvr.nic.cz` | [Add to AdGuard](adguard:add_dns_server?address=tls://odvr.nic.cz&name=odvr.nic.cz), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://odvr.nic.cz&name=odvr.nic.cz) |
 
@@ -866,10 +853,10 @@ Access to AI, blocking of ads, counters, phishing and malicious websites.
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS-over-HTTPS | `https://dns-doh.dnsforfamily.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://https://dns-doh.dnsforfamily.com/dns-query&name=https://dns-doh.dnsforfamily.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://https://dns-doh.dnsforfamily.com/dns-query&name=https://dns-doh.dnsforfamily.com) |
+| DNS-over-HTTPS | `https://dns-doh.dnsforfamily.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dns-doh.dnsforfamily.com/dns-query&name=dns-doh.dnsforfamily.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns-doh.dnsforfamily.com/dns-query&name=dns-doh.dnsforfamily.com) |
 | DNS-over-TLS | `tls://dns-dot.dnsforfamily.com` | [Add to AdGuard](adguard:add_dns_server?address=tls://dns-dot.dnsforfamily.com&name=dns-dot.dnsforfamily.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dns-dot.dnsforfamily.com&name=dns-dot.dnsforfamily.com) |
-| DNS, IPv4 | `94.130.180.225` and `78.47.64.161` | [Add to AdGuard](adguard:add_dns_server?address=94.130.180.225&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=94.130.180.225&name=) |
-| DNS, IPv6 | `2a01:4f8:1c0c:40db::1` and `2a01:4f8:1c17:4df8::1` | [Add to AdGuard](adguard:add_dns_server?address=2a01:4f8:1c0c:40db::1&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a01:4f8:1c0c:40db::1&name=) |
+| DNS, IPv4 | `94.130.180.225` and `78.47.64.161` | [Add to AdGuard](adguard:add_dns_server?address=94.130.180.225&name=DNS%20for%20Family), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=94.130.180.225&name=DNS%20for%20Family) |
+| DNS, IPv6 | `2a01:4f8:1c0c:40db::1` and `2a01:4f8:1c17:4df8::1` | [Add to AdGuard](adguard:add_dns_server?address=2a01:4f8:1c0c:40db::1&name=DNS%20for%20Family), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a01:4f8:1c0c:40db::1&name=DNS%20for%20Family) |
 | DNSCrypt, IPv4 | Provider: `dnsforfamily.com` IP: `94.130.180.225`| [Add to AdGuard](sdns://AQIAAAAAAAAADjk0LjEzMC4xODAuMjI1ILtn1Ada3rLi6VNcj4pB-I5eHBqFzFbs_XFRHG-6KenTEGRuc2ZvcmZhbWlseS5jb20) |
 | DNSCrypt, IPv6 | Provider: `dnsforfamily.com` IP: `[2a01:4f8:1c0c:40db::1]`| [Add to AdGuard](sdns://AQIAAAAAAAAAF1syYTAxOjRmODoxYzBjOjQwZGI6OjFdIKeNqJacdMufL_kvUDGFm5-J2r4yS94vn4S5ie-o8MCMEGRuc2ZvcmZhbWlseS5jb20) |
 
@@ -883,9 +870,9 @@ Blocks access to known malicious and fraudulent websites.
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `86.54.11.1` and `86.54.11.201` | [Add to AdGuard](adguard:add_dns_server?address=86.54.11.1&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=86.54.11.1&name=) |
-| DNS, IPv6 | `2a13:1001::86:54:11:1` and `2a13:1001::86:54:11:201` | [Add to AdGuard](adguard:add_dns_server?address=2a13:1001::86:54:11:1&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a13:1001::86:54:11:1&name=) |
-| DNS-over-HTTPS | `https://protective.joindns4.eu/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://protective.joindns4.eu/dns-query&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://protective.joindns4.eu/dns-query&name=) |
+| DNS, IPv4 | `86.54.11.1` and `86.54.11.201` | [Add to AdGuard](adguard:add_dns_server?address=86.54.11.1&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=86.54.11.1&name=DNS4EU) |
+| DNS, IPv6 | `2a13:1001::86:54:11:1` and `2a13:1001::86:54:11:201` | [Add to AdGuard](adguard:add_dns_server?address=2a13:1001::86:54:11:1&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a13:1001::86:54:11:1&name=DNS4EU) |
+| DNS-over-HTTPS | `https://protective.joindns4.eu/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://protective.joindns4.eu/dns-query&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://protective.joindns4.eu/dns-query&name=DNS4EU) |
 | DNS-over-TLS | `tls://protective.joindns4.eu` | [Add to AdGuard](adguard:add_dns_server?address=tls://protective.joindns4.eu&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://protective.joindns4.eu&name=DNS4EU) |
 
 #### Protective resolution with child protection
@@ -894,10 +881,10 @@ Avoid access to websites inappropriate for children such as explicit content, vi
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `86.54.11.12` and `86.54.11.212` | [Add to AdGuard](adguard:add_dns_server?address=86.54.11.12&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=86.54.11.12&name=) |
-| DNS, IPv6 | `2a13:1001::86:54:11:12` and `2a13:1001::86:54:11:212` | [Add to AdGuard](adguard:add_dns_server?address=2a13:1001::86:54:11:12&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a13:1001::86:54:11:12&name=) |
-| DNS-over-HTTPS | `https://child.joindns4.eu/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://child.joindns4.eu/dns-query&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://child.joindns4.eu/dns-query&name=) |
-| DNS-over-TLS | `tls://child.joindns4.eu` | [Add to AdGuard](adguard:add_dns_server?address=tls://child.joindns4.eu&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://child.joindns4.eu&name=) |
+| DNS, IPv4 | `86.54.11.12` and `86.54.11.212` | [Add to AdGuard](adguard:add_dns_server?address=86.54.11.12&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=86.54.11.12&name=DNS4EU) |
+| DNS, IPv6 | `2a13:1001::86:54:11:12` and `2a13:1001::86:54:11:212` | [Add to AdGuard](adguard:add_dns_server?address=2a13:1001::86:54:11:12&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a13:1001::86:54:11:12&name=DNS4EU) |
+| DNS-over-HTTPS | `https://child.joindns4.eu/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://child.joindns4.eu/dns-query&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://child.joindns4.eu/dns-query&name=DNS4EU) |
+| DNS-over-TLS | `tls://child.joindns4.eu` | [Add to AdGuard](adguard:add_dns_server?address=tls://child.joindns4.eu&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://child.joindns4.eu&name=DNS4EU) |
 
 #### Protective resolution with ad blocking
 
@@ -905,10 +892,10 @@ Hide website and in-app ads on top of the protective functionality.
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `86.54.11.13` and `86.54.11.213` | [Add to AdGuard](adguard:add_dns_server?address=86.54.11.13&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=86.54.11.13&name=) |
-| DNS, IPv6 | `2a13:1001::86:54:11:13` and `2a13:1001::86:54:11:213` | [Add to AdGuard](adguard:add_dns_server?address=2a13:1001::86:54:11:13&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a13:1001::86:54:11:13&name=) |
-| DNS-over-HTTPS | `https://noads.joindns4.eu/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://noads.joindns4.eu/dns-query&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://noads.joindns4.eu/dns-query&name=) |
-| DNS-over-TLS | `tls://noads.joindns4.eu` | [Add to AdGuard](adguard:add_dns_server?address=tls://noads.joindns4.eu&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://noads.joindns4.eu&name=) |
+| DNS, IPv4 | `86.54.11.13` and `86.54.11.213` | [Add to AdGuard](adguard:add_dns_server?address=86.54.11.13&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=86.54.11.13&name=DNS4EU) |
+| DNS, IPv6 | `2a13:1001::86:54:11:13` and `2a13:1001::86:54:11:213` | [Add to AdGuard](adguard:add_dns_server?address=2a13:1001::86:54:11:13&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a13:1001::86:54:11:13&name=DNS4EU) |
+| DNS-over-HTTPS | `https://noads.joindns4.eu/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://noads.joindns4.eu/dns-query&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://noads.joindns4.eu/dns-query&name=DNS4EU) |
+| DNS-over-TLS | `tls://noads.joindns4.eu` | [Add to AdGuard](adguard:add_dns_server?address=tls://noads.joindns4.eu&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://noads.joindns4.eu&name=DNS4EU) |
 
 #### Protective resolution with child protection and ad blocking
 
@@ -916,10 +903,10 @@ Avoid access to websites inappropriate for children, such as explicit content, v
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `86.54.11.11` and `86.54.11.211` | [Add to AdGuard](adguard:add_dns_server?address=86.54.11.11&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=86.54.11.11&name=) |
-| DNS, IPv6 | `2a13:1001::86:54:11:11` and `2a13:1001::86:54:11:211` | [Add to AdGuard](adguard:add_dns_server?address=2a13:1001::86:54:11:11&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a13:1001::86:54:11:11&name=) |
-| DNS-over-HTTPS | `https://child-noads.joindns4.eu/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://child-noads.joindns4.eu/dns-query&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://child-noads.joindns4.eu/dns-query&name=) |
-| DNS-over-TLS | `tls://child-noads.joindns4.eu` | [Add to AdGuard](adguard:add_dns_server?address=tls://child-noads.joindns4.eu&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://child-noads.joindns4.eu&name=) |
+| DNS, IPv4 | `86.54.11.11` and `86.54.11.211` | [Add to AdGuard](adguard:add_dns_server?address=86.54.11.11&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=86.54.11.11&name=DNS4EU) |
+| DNS, IPv6 | `2a13:1001::86:54:11:11` and `2a13:1001::86:54:11:211` | [Add to AdGuard](adguard:add_dns_server?address=2a13:1001::86:54:11:11&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a13:1001::86:54:11:11&name=DNS4EU) |
+| DNS-over-HTTPS | `https://child-noads.joindns4.eu/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://child-noads.joindns4.eu/dns-query&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://child-noads.joindns4.eu/dns-query&name=DNS4EU) |
+| DNS-over-TLS | `tls://child-noads.joindns4.eu` | [Add to AdGuard](adguard:add_dns_server?address=tls://child-noads.joindns4.eu&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://child-noads.joindns4.eu&name=DNS4EU) |
 
 #### Unfiltered resolution
 
@@ -927,47 +914,10 @@ Unfiltered option is a valid option for users who are confident their devices an
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `86.54.11.100` and `86.54.11.200` | [Add to AdGuard](adguard:add_dns_server?address=86.54.11.100&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=86.54.11.100&name=) |
-| DNS, IPv6 | `2a13:1001::86:54:11:100` and `2a13:1001::86:54:11:100` | [Add to AdGuard](adguard:add_dns_server?address=2a13:1001::86:54:11:100&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a13:1001::86:54:11:100&name=) |
-| DNS-over-HTTPS | `https://unfiltered.joindns4.eu/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://child-noads.joindns4.eu/dns-query&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://child-noads.joindns4.eu/dns-query&name=) |
-| DNS-over-TLS | `tls://child-noads.joindns4.eu` | [Add to AdGuard](adguard:add_dns_server?address=tls://child-noads.joindns4.eu&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://child-noads.joindns4.eu&name=) |
-
-### Fondation Restena DNS
-
-[Restena DNS](https://www.restena.lu/en/service/public-dns-resolver) servers provided by [Restena Foundation](https://www.restena.lu/).
-
-| Protocol | Address | |
-|----------------|----------------------------------------------------|----------------|
-| DNS-over-HTTPS | `https://kaitain.restena.lu/dns-query` IP: `158.64.1.29` and IPv6: `2001:a18:1::29` | [Add to AdGuard](adguard:add_dns_server?address=https://kaitain.restena.lu/dns-query&name=kaitain.restena.lu), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://kaitain.restena.lu/dns-query&name=kaitain.restena.lu) |
-| DNS-over-TLS| `tls://kaitain.restena.lu` IP: `158.64.1.29` and IPv6: `2001:a18:1::29` | [Add to AdGuard](adguard:add_dns_server?address=tls://kaitain.restena.lu&name=kaitain.restena.lu), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://kaitain.restena.lu&name=kaitain.restena.lu) |
-
-### 114DNS
-
-[114DNS](https://www.114dns.com) is a professional and high-reliability DNS service.
-
-#### Normal
-
-Block ads and annoying websites.
-
-| Protocol | Address | |
-|----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `114.114.114.114` and `114.114.115.115` | [Add to AdGuard](adguard:add_dns_server?address=114.114.114.114&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=114.114.114.114&name=) |
-
-#### Safe
-
-Blocks phishing, malicious and other unsafe websites.
-
-| Protocol | Address | |
-|----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `114.114.114.119` and `114.114.115.119` | [Add to AdGuard](adguard:add_dns_server?address=114.114.114.119&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=114.114.114.119&name=) |
-
-#### Family
-
-These servers block adult websites and inappropriate contents.
-
-| Protocol | Address | |
-|----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `114.114.114.110` and `114.114.115.110` | [Add to AdGuard](adguard:add_dns_server?address=114.114.114.110&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=114.114.114.110&name=) |
+| DNS, IPv4 | `86.54.11.100` and `86.54.11.200` | [Add to AdGuard](adguard:add_dns_server?address=86.54.11.100&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=86.54.11.100&name=DNS4EU) |
+| DNS, IPv6 | `2a13:1001::86:54:11:100` and `2a13:1001::86:54:11:100` | [Add to AdGuard](adguard:add_dns_server?address=2a13:1001::86:54:11:100&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a13:1001::86:54:11:100&name=DNS4EU) |
+| DNS-over-HTTPS | `https://unfiltered.joindns4.eu/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://unfiltered.joindns4.eu/dns-query&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://unfiltered.joindns4.eu/dns-query&name=DNS4EU) |
+| DNS-over-TLS | `tls://unfiltered.joindns4.eu` | [Add to AdGuard](adguard:add_dns_server?address=tls://unfiltered.joindns4.eu&name=DNS4EU), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://unfiltered.joindns4.eu&name=DNS4EU) |
 
 ### IIJ.JP DNS
 
@@ -982,6 +932,8 @@ These servers block adult websites and inappropriate contents.
 
 [JupitrDNS](https://jupitrdns.com/) is a free security-focused recursive DNS service that blocks malware. It has DNSSEC support and does not store logs.
 
+*Note: The TLS certificate for encrypted endpoints is issued by a Let's Encrypt staging CA, which may not be trusted by standard clients. Encrypted DNS (DoH/DoT/DoQ) may not work without disabling certificate validation.*
+
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
 | DNS, IPv4 | `155.248.232.226` | [Add to AdGuard](adguard:add_dns_server?address=155.248.232.226&name=dns.jupitrdns.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=155.248.232.226&name=dns.jupitrdns.com) |
@@ -995,7 +947,7 @@ These servers block adult websites and inappropriate contents.
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `88.198.92.222` | [Add to AdGuard](adguard:add_dns_server?address=88.198.92.222&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=88.198.92.222&name=) |
+| DNS, IPv4 | `88.198.92.222` | [Add to AdGuard](adguard:add_dns_server?address=88.198.92.222&name=LibreDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=88.198.92.222&name=LibreDNS) |
 | DNS-over-HTTPS | `https://doh.libredns.gr/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://doh.libredns.gr/dns-query&name=doh.libredns.gr), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh.libredns.gr/dns-query&name=doh.libredns.gr) |
 | DNS-over-HTTPS | `https://doh.libredns.gr/ads` | [Add to AdGuard](adguard:add_dns_server?address=https://doh.libredns.gr/ads&name=doh.libredns.gr), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh.libredns.gr/ads&name=doh.libredns.gr) |
 | DNS-over-TLS | `tls://dot.libredns.gr` IP: `116.202.176.26` | [Add to AdGuard](adguard:add_dns_server?address=tls://dot.libredns.gr&name=dot.libredns.gr), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dot.libredns.gr&name=dot.libredns.gr) |
@@ -1008,8 +960,8 @@ These servers block adult websites and inappropriate contents.
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `117.50.10.10` and `52.80.52.52` | [Add to AdGuard](adguard:add_dns_server?address=117.50.10.10&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=117.50.10.10&name=) |
-| DNS, IPv6 | `2400:7fc0:849e:200::8` and `2404:c2c0:85d8:901::8` | [Add to AdGuard](adguard:add_dns_server?address=2400:7fc0:849e:200::8&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2400:7fc0:849e:200::8&name=) |
+| DNS, IPv4 | `117.50.10.10` and `52.80.52.52` | [Add to AdGuard](adguard:add_dns_server?address=117.50.10.10&name=OneDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=117.50.10.10&name=OneDNS) |
+| DNS, IPv6 | `2400:7fc0:849e:200::8` and `2404:c2c0:85d8:901::8` | [Add to AdGuard](adguard:add_dns_server?address=2400:7fc0:849e:200::8&name=OneDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2400:7fc0:849e:200::8&name=OneDNS) |
 | DNS-over-HTTPS | `https://doh-pure.onedns.net/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://doh-pure.onedns.net/dns-query&name=doh-pure.onedns.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh-pure.onedns.net/dns-query&name=doh-pure.onedns.net) |
 | DNS-over-TLS | `tls://dot-pure.onedns.net` | [Add to AdGuard](adguard:add_dns_server?address=tls://dot-pure.onedns.net&name=dot-pure.onedns.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dot-pure.onedns.net&name=dot-pure.onedns.net) |
 
@@ -1017,8 +969,8 @@ These servers block adult websites and inappropriate contents.
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `52.80.66.66` and `117.50.22.22` | [Add to AdGuard](adguard:add_dns_server?address=52.80.66.66&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=52.80.66.66&name=) |
-| DNS, IPv6 | `2400:7fc0:849e:200::4` and `2404:c2c0:85d8:901::4` | [Add to AdGuard](adguard:add_dns_server?address=2400:7fc0:849e:200::4&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2400:7fc0:849e:200::4&name=) |
+| DNS, IPv4 | `52.80.66.66` and `117.50.22.22` | [Add to AdGuard](adguard:add_dns_server?address=52.80.66.66&name=OneDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=52.80.66.66&name=OneDNS) |
+| DNS, IPv6 | `2400:7fc0:849e:200::4` and `2404:c2c0:85d8:901::4` | [Add to AdGuard](adguard:add_dns_server?address=2400:7fc0:849e:200::4&name=OneDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2400:7fc0:849e:200::4&name=OneDNS) |
 | DNS-over-HTTPS | `https://doh.onedns.net/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://doh.onedns.net/dns-query&name=doh.onedns.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh.onedns.net/dns-query&name=doh.onedns.net) |
 | DNS-over-TLS | `tls://dot.onedns.net` | [Add to AdGuard](adguard:add_dns_server?address=tls://dot.onedns.net&name=dot.onedns.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dot.onedns.net&name=dot.onedns.net) |
 
@@ -1026,7 +978,7 @@ These servers block adult websites and inappropriate contents.
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `117.50.60.30` and `52.80.60.30` | [Add to AdGuard](adguard:add_dns_server?address=117.50.60.30&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=117.50.60.30&name=) |
+| DNS, IPv4 | `117.50.60.30` and `52.80.60.30` | [Add to AdGuard](adguard:add_dns_server?address=117.50.60.30&name=OneDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=117.50.60.30&name=OneDNS) |
 
 ### OpenNIC DNS
 
@@ -1034,8 +986,8 @@ These servers block adult websites and inappropriate contents.
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `217.160.70.42` | [Add to AdGuard](adguard:add_dns_server?address=217.160.70.42&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=217.160.70.42&name=) |
-| DNS, IPv6 | `2001:8d8:1801:86e7::1` | [Add to AdGuard](adguard:add_dns_server?address=2001:8d8:1801:86e7::1&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:8d8:1801:86e7::1&name=) |
+| DNS, IPv4 | `217.160.70.42` | [Add to AdGuard](adguard:add_dns_server?address=217.160.70.42&name=OpenNIC), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=217.160.70.42&name=OpenNIC) |
+| DNS, IPv6 | `2001:8d8:1801:86e7::1` | [Add to AdGuard](adguard:add_dns_server?address=2001:8d8:1801:86e7::1&name=OpenNIC), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:8d8:1801:86e7::1&name=OpenNIC) |
 
 This is just one of the available servers, the full list can be found on the [OpenNIC public servers page](https://servers.opennic.org/).
 
@@ -1045,8 +997,8 @@ This is just one of the available servers, the full list can be found on the [Op
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `101.101.101.101` and `101.102.103.104` | [Add to AdGuard](adguard:add_dns_server?address=101.101.101.101&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=101.101.101.101&name=) |
-| DNS, IPv6 | `2001:de4::101` and `2001:de4::102` | [Add to AdGuard](adguard:add_dns_server?address=2001:de4::101&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:de4::101&name=) |
+| DNS, IPv4 | `101.101.101.101` and `101.102.103.104` | [Add to AdGuard](adguard:add_dns_server?address=101.101.101.101&name=Quad101), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=101.101.101.101&name=Quad101) |
+| DNS, IPv6 | `2001:de4::101` and `2001:de4::102` | [Add to AdGuard](adguard:add_dns_server?address=2001:de4::101&name=Quad101), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:de4::101&name=Quad101) |
 | DNS-over-TLS | `tls://101.101.101.101` | [Add to AdGuard](adguard:add_dns_server?address=tls://101.101.101.101&name=101.101.101.101), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://101.101.101.101&name=101.101.101.101) |
 
 ### SkyDNS RU
@@ -1055,7 +1007,7 @@ This is just one of the available servers, the full list can be found on the [Op
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `193.58.251.251` | [Add to AdGuard](adguard:add_dns_server?address=193.58.251.251&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=193.58.251.251&name=) |
+| DNS, IPv4 | `193.58.251.251` | [Add to AdGuard](adguard:add_dns_server?address=193.58.251.251&name=SkyDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=193.58.251.251&name=SkyDNS) |
 
 ### SWITCH DNS
 
@@ -1063,25 +1015,27 @@ This is just one of the available servers, the full list can be found on the [Op
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | Provider: `dns.switch.ch` IP: `130.59.31.248` | [Add to AdGuard](adguard:add_dns_server?address=130.59.31.248&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=130.59.31.248&name=) |
-| DNS, IPv6 | Provider: `dns.switch.ch` IPv6: `2001:620:0:ff::2` | [Add to AdGuard](adguard:add_dns_server?address=2001:620:0:ff::2&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:620:0:ff::2&name=) |
+| DNS, IPv4 | Provider: `dns.switch.ch` IP: `130.59.31.248` | [Add to AdGuard](adguard:add_dns_server?address=130.59.31.248&name=SWITCH%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=130.59.31.248&name=SWITCH%20DNS) |
+| DNS, IPv6 | Provider: `dns.switch.ch` IPv6: `2001:620:0:ff::2` | [Add to AdGuard](adguard:add_dns_server?address=2001:620:0:ff::2&name=SWITCH%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:620:0:ff::2&name=SWITCH%20DNS) |
 | DNS-over-HTTPS | `https://dns.switch.ch/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.switch.ch/dns-query&name=dns.switch.ch), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.switch.ch/dns-query&name=dns.switch.ch) |
 | DNS-over-TLS | Hostname: `tls://dns.switch.ch` IP: `130.59.31.248` and IPv6: `2001:620:0:ff::2` | [Add to AdGuard](adguard:add_dns_server?address=tls://dns.switch.ch&name=dns.switch.ch), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dns.switch.ch&name=dns.switch.ch) |
 
 ### UK DNS Privacy Project
 
-[UK DNS Privacy Project](https://dnsprivacy.org.uk) is a public DNS service based in the United Kingdom with no tracking, no logging, DNSSEC enabled
+[UK DNS Privacy Project](https://dnsprivacy.org.uk) is a public DNS service based in the United Kingdom with no tracking, no logging, DNSSEC enabled.
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `209.250.227.42` and `64.176.190.82` | [Add to AdGuard](adguard:add_dns_server?address=209.250.227.42&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=209.250.227.42&name=) |
-| DNS, IPv6 | `2001:19f0:7400:13c7:5400:05ff:fe40:d1ad` | [Add to AdGuard](adguard:add_dns_server?address=2001:19f0:7400:13c7:5400:05ff:fe40:d1ad&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:19f0:7400:13c7:5400:05ff:fe40:d1ad&name=) |
+| DNS, IPv4 | `209.250.227.42` and `64.176.190.82` | [Add to AdGuard](adguard:add_dns_server?address=209.250.227.42&name=UK%20DNS%20Privacy), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=209.250.227.42&name=UK%20DNS%20Privacy) |
+| DNS, IPv6 | `2001:19f0:7400:13c7:5400:05ff:fe40:d1ad` | [Add to AdGuard](adguard:add_dns_server?address=2001:19f0:7400:13c7:5400:05ff:fe40:d1ad&name=UK%20DNS%20Privacy), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:19f0:7400:13c7:5400:05ff:fe40:d1ad&name=UK%20DNS%20Privacy) |
 |DNS-over-HTTPS|`https://resolver.dnsprivacy.org.uk/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://resolver.dnsprivacy.org.uk/dns-query&name=dnsprivacy.org.uk), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://resolver.dnsprivacy.org.uk/dns-query&name=dnsprivacy.org.uk) |
 |DNS-over-TLS|`tls://resolver.dnsprivacy.org.uk` | [Add to AdGuard](adguard:add_dns_server?address=tls://resolver.dnsprivacy.org.uk&name=dnsprivacy.org.uk), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://resolver.dnsprivacy.org.uk&name=dnsprivacy.org.uk) |
 
 ### Xstl DNS
 
 [Xstl DNS](https://get.dns.seia.io/) is a public DNS service based in South Korea that doesn’t log the user’s IP. Ads & trackers are blocked.
+
+*Note: Encrypted DNS hostnames (dns.seia.io, secondary.dns.seia.io) are currently not resolving. Only plain DNS IPs (116.121.57.111, 140.238.14.191) are confirmed operational. This may be a transient issue.*
 
 #### SK Broadband
 
@@ -1138,7 +1092,7 @@ In *Family* mode, protection from infected, fraudulent and adult sites is provid
 
 These are DNS resolvers usually run by enthusiasts or small groups. While they may lack the scale and redundancy of larger providers, they often prioritize privacy, transparency, or offer specialized features.
 
-We won’t be able to proper monitor their availability. **Use them at your own risk.**
+We won’t be able to properly monitor their availability. **Use them at your own risk.**
 
 ### 18Bit DNS
 
@@ -1151,14 +1105,14 @@ We won’t be able to proper monitor their availability. **Use them at your own 
 
 ### AhaDNS
 
-[AhaDNS](https://ahadns.com/) A zero-logging and ad-blocking DNS service provided by Fredrik Pettersson.
+[AhaDNS](https://ahadns.com/). A zero-logging and ad-blocking DNS service provided by Fredrik Pettersson.
 
 #### Netherlands
 
 | Protocol | Address | |
 |----------------|-------------------------------------|----------------|
-| DNS, IPv4 | `5.2.75.75` | [Add to AdGuard](adguard:add_dns_server?address=5.2.75.75&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=5.2.75.75&name=) |
-| DNS, IPv6 | `2a04:52c0:101:75::75` | [Add to AdGuard](adguard:add_dns_server?address=2a04:52c0:101:75::75&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a04:52c0:101:75::75&name=) |
+| DNS, IPv4 | `5.2.75.75` | [Add to AdGuard](adguard:add_dns_server?address=5.2.75.75&name=AhaDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=5.2.75.75&name=AhaDNS) |
+| DNS, IPv6 | `2a04:52c0:101:75::75` | [Add to AdGuard](adguard:add_dns_server?address=2a04:52c0:101:75::75&name=AhaDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a04:52c0:101:75::75&name=AhaDNS) |
 | DNS-over-HTTPS | `https://doh.nl.ahadns.net/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://doh.nl.ahadns.net/dns-query&name=doh.nl.ahadns.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh.nl.ahadns.net/dns-query&name=doh.nl.ahadns.net) |
 | DNS-over-TLS | `tls://dot.nl.ahadns.net` | [Add to AdGuard](adguard:add_dns_server?address=tls://dot.nl.ahadns.net&name=dot.nl.ahadns.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dot.nl.ahadns.net&name=dot.nl.ahadns.net) |
 
@@ -1166,21 +1120,10 @@ We won’t be able to proper monitor their availability. **Use them at your own 
 
 | Protocol | Address | |
 |----------------|-------------------------------------|----------------|
-| DNS, IPv4 | `45.67.219.208` | [Add to AdGuard](adguard:add_dns_server?address=45.67.219.208&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=45.67.219.208&name=) |
-| DNS, IPv6 | `2a04:bdc7:100:70::70` | [Add to AdGuard](adguard:add_dns_server?address=2a04:bdc7:100:70::70&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a04:bdc7:100:70::70&name=) |
+| DNS, IPv4 | `45.67.219.208` | [Add to AdGuard](adguard:add_dns_server?address=45.67.219.208&name=AhaDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=45.67.219.208&name=AhaDNS) |
+| DNS, IPv6 | `2a04:bdc7:100:70::70` | [Add to AdGuard](adguard:add_dns_server?address=2a04:bdc7:100:70::70&name=AhaDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a04:bdc7:100:70::70&name=AhaDNS) |
 | DNS-over-HTTPS | `https://doh.la.ahadns.net/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://doh.la.ahadns.net/dns-query&name=doh.la.ahadns.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh.la.ahadns.net/dns-query&name=doh.la.ahadns.net) |
 | DNS-over-TLS | `tls://dot.la.ahadns.net` | [Add to AdGuard](adguard:add_dns_server?address=tls://dot.la.ahadns.net&name=dot.la.ahadns.net), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dot.la.ahadns.net&name=dot.la.ahadns.net) |
-
-### Arapurayil
-
-[Arapurayil](https://dns.arapurayil.com) is a personal DNS service hosted in Mumbai, India.
-
-Non-logging | Filters ads, trackers, phishing, etc. | DNSSEC | QNAME Minimization | No EDNS Client Subnet.
-
-| Protocol       | Address                    |                                                        |
-|----------------|------------------------------------------------------------------|------------------|
-| DNSCrypt, IPv4 | Host: `2.dnscrypt-cert.dns.arapurayil.com` IP: `3.7.156.128` | [Add to AdGuard](sdns://AQMAAAAAAAAAEDMuNy4xNTYuMTI4Ojg0NDMgDXD9OSDJDwe2q9bi836PURTP14NLYS03RbDq6j891ZciMi5kbnNjcnlwdC1jZXJ0LmRucy5hcmFwdXJheWlsLmNvbQ) |
-| DNS-over-HTTPS | Host: `https://dns.arapurayil.com/dns-query`                 | [Add to AdGuard](adguard:add_dns_server?address=https://dns.arapurayil.com/dns-query&name=dns.arapurayil.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.arapurayil.com/dns-query&name=dns.arapurayil.com)  |
 
 ### ASTRACAT DNS
 
@@ -1196,12 +1139,12 @@ Non-logging | Filters ads, trackers, phishing, etc. | DNSSEC | QNAME Minimizatio
 
 [BlackMagicc DNS](https://bento.me/blackmagicc) is a personal DNS server located in Vietnam and intended for personal and small-scale use. It features ad blocking, malware/phishing protection, adult content filter, and DNSSEC validation.
 
+*Note: Encrypted DNS (DoH/DoQ) is currently unavailable; only plain DNS (IPv4/IPv6) is operational.*
+
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
 | DNS, IPv4 | `103.70.12.129` | [Add to AdGuard](adguard:add_dns_server?address=103.70.12.129&name=BlackMagiccDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=103.70.12.129&name=BlackMagiccDNS) |
 | DNS, IPv6 | `2001:df4:4c0:1::399:1` | [Add to AdGuard](adguard:add_dns_server?address=2001:df4:4c0:1::399:1&name=BlackMagiccDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:df4:4c0:1::399:1&name=BlackMagiccDNS) |
-| DNS-over-QUIC | `quic://rx.techomespace.com` | [Add to AdGuard](adguard:add_dns_server?address=quic://rx.techomespace.com&name=BlackMagiccDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=quic://rx.techomespace.com&name=BlackMagiccDNS)  |
-| DNS-over-HTTPS | `https://rx.techomespace.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://rx.techomespace.com/dns-query&name=BlackMagiccDNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://rx.techomespace.com/dns-query&name=BlackMagiccDNS) |
 
 ### Captnemo DNS
 
@@ -1211,39 +1154,28 @@ Non-logging | Filters ads, trackers, phishing, etc. | DNSSEC | QNAME Minimizatio
 |----------------|----------------------------------------------------|----------------|
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.captnemo.in` IP: `139.59.48.222:4434` | [Add to AdGuard](sdns://AQQAAAAAAAAAEjEzOS41OS40OC4yMjI6NDQzNCAFOt_yxaMpFtga2IpneSwwK6rV0oAyleham9IvhoceEBsyLmRuc2NyeXB0LWNlcnQuY2FwdG5lbW8uaW4) |
 
-### DNSGuard
-
-[DNSGuard](https://dnsguard.pub) blocks ads, tracking, and malware and has a strict no-logging policy.
-
-| Protocol         | Address                                             |                |
-|------------------|-----------------------------------------------------|----------------|
-| DNS 1, IPv4     | `62.192.153.242`                                    | [Add to AdGuard](adguard:add_dns_server?address=62.192.153.242&name=DNSGUARD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=62.192.153.242&name=DNSGUARD) |
-| DNS 2, IPv4     | `62.192.153.243`                                    | [Add to AdGuard](adguard:add_dns_server?address=62.192.153.243&name=DNSGUARD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=62.192.153.243&name=DNSGUARD) |
-| DNS 1, IPv6     | `2a0c:4ac1:29::2`                                    | [Add to AdGuard](adguard:add_dns_server?address=2a0c:4ac1:29::2&name=DNSGUARD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a0c:4ac1:29::2&name=DNSGUARD) |
-| DNS 2, IPv6     | `2a0c:4ac1:29::3`                                    | [Add to AdGuard](adguard:add_dns_server?address=2a0c:4ac1:29::3&name=DNSGUARD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a0c:4ac1:29::3&name=DNSGUARD) |
-| DNS-over-HTTPS   | `https://dns.dnsguard.pub/dns-query`                    | [Add to AdGuard](adguard:add_dns_server?address=https://dns.dnsguard.pub/dns-query&name=DNSGUARD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.dnsguard.pub/dns-query&name=DNSGUARD) |
-| DNS-over-TLS     | `tls://dns.dnsguard.pub`                                | [Add to AdGuard](adguard:add_dns_server?address=tls://dns.dnsguard.pub&name=DNSGUARD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dns.dnsguard.pub&name=DNSGUARD) |
-| DNS-over-QUIC    | `quic://dns.dnsguard.pub`                               | [Add to AdGuard](adguard:add_dns_server?address=quic://dns.dnsguard.pub&name=DNSGUARD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=quic://dns.dnsguard.pub&name=DNSGUARD) |
-
 ### DNS Forge
 
 [DNS Forge](https://dnsforge.de/) is a redundant DNS resolver with an ad blocker and no logging provided by [adminforge](https://adminforge.de/).
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `176.9.93.198` and `176.9.1.117` | [Add to AdGuard](adguard:add_dns_server?address=176.9.93.198&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=176.9.93.198&name=) |
-| DNS, IPv6 | `2a01:4f8:151:34aa::198` and `2a01:4f8:141:316d::117` | [Add to AdGuard](adguard:add_dns_server?address=2a01:4f8:151:34aa::198&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a01:4f8:151:34aa::198&name=) |
+| DNS, IPv4 | `176.9.93.198` and `176.9.1.117` | [Add to AdGuard](adguard:add_dns_server?address=176.9.93.198&name=DNS%20Forge), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=176.9.93.198&name=DNS%20Forge) |
+| DNS, IPv6 | `2a01:4f8:151:34aa::198` and `2a01:4f8:141:316d::117` | [Add to AdGuard](adguard:add_dns_server?address=2a01:4f8:151:34aa::198&name=DNS%20Forge), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a01:4f8:151:34aa::198&name=DNS%20Forge) |
 | DNS-over-HTTPS | `https://dnsforge.de/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dnsforge.de/dns-query&name=dnsforge.de), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dnsforge.de/dns-query&name=dnsforge.de) |
 | DNS-over-TLS | `tls://dnsforge.de` | [Add to AdGuard](adguard:add_dns_server?address=tls://dnsforge.de&name=dnsforge.de), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dnsforge.de&name=dnsforge.de) |
 
-### dnswarden
+### DNSGuard
 
-| Protocol | Address | |
-|----------------|----------------------------------------------------|----------------|
-| DNS-over-TLS | `uncensored.dns.dnswarden.com` | [Add to AdGuard](adguard:add_dns_server?address=huncensored.dns.dnswarden.com&name=uncensored.dns.dnswarden.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=huncensored.dns.dnswarden.com&uncensored.dns.dnswarden.com) |
-| DNS-over-HTTPS | `https://dns.dnswarden.com/uncensored` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.dnswarden.com/uncensored&name=https://dns.dnswarden.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.dnswarden.com/uncensored&https://dns.dnswarden.com) |
+[DNSGuard](https://dnsguard.pub) blocks ads, tracking, and malware and has a strict no-logging policy.
 
-You can also [configure custom DNS server](https://dnswarden.com/customfilter.html) to block ads or filter adult content.
+| Protocol         | Address                                             |                |
+|------------------|-----------------------------------------------------|----------------|
+| DNS, IPv4     | `62.192.153.242` and `62.192.153.243`                                    | [Add to AdGuard](adguard:add_dns_server?address=62.192.153.242&name=DNSGUARD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=62.192.153.242&name=DNSGUARD) |
+| DNS, IPv6     | `2a0c:4ac1:29::2` and `2a0c:4ac1:29::3`                                    | [Add to AdGuard](adguard:add_dns_server?address=2a0c:4ac1:29::2&name=DNSGUARD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2a0c:4ac1:29::2&name=DNSGUARD) |
+| DNS-over-HTTPS   | `https://dns.dnsguard.pub/dns-query`                    | [Add to AdGuard](adguard:add_dns_server?address=https://dns.dnsguard.pub/dns-query&name=DNSGUARD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.dnsguard.pub/dns-query&name=DNSGUARD) |
+| DNS-over-TLS     | `tls://dns.dnsguard.pub`                                | [Add to AdGuard](adguard:add_dns_server?address=tls://dns.dnsguard.pub&name=DNSGUARD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dns.dnsguard.pub&name=DNSGUARD) |
+| DNS-over-QUIC    | `quic://dns.dnsguard.pub`                               | [Add to AdGuard](adguard:add_dns_server?address=quic://dns.dnsguard.pub&name=DNSGUARD), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=quic://dns.dnsguard.pub&name=DNSGUARD) |
 
 ### FFMUC DNS
 
@@ -1260,7 +1192,7 @@ You can also [configure custom DNS server](https://dnswarden.com/customfilter.ht
 
 ### fvz DNS
 
-[fvz DNS](http://meo.ws/) is a Fusl’s public primary OpenNIC Tier2 Anycast DNS Resolver.
+[fvz DNS](http://meo.ws/) is a Fusl's public primary OpenNIC Tier2 Anycast DNS Resolver.
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
@@ -1308,15 +1240,6 @@ The service supports encrypted DNS protocols only and does not log individual DN
 | DNS-over-HTTPS, IPv4 | Hostname: `https://ibksturm.synology.me/dns-query` IP: `213.196.191.96` | [Add to AdGuard](adguard:add_dns_server?address=https://ibksturm.synology.me/dns-query&name=ibksturm.synology.me), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://ibksturm.synology.me/dns-query&name=ibksturm.synology.me) |
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.ibksturm` IP: `213.196.191.96:8443` | [Add to AdGuard](sdns://AQcAAAAAAAAAEzIxMy4xOTYuMTkxLjk2Ojg0NDMgK374BJKvK0aJHWKjmXdkG8_X2KEoao_LALK_nK6PM_AYMi5kbnNjcnlwdC1jZXJ0Lmlia3N0dXJt) |
 
-### Lelux DNS
-
-[Lelux.fi](https://lelux.fi/resolver/) is run by Elias Ojala, Finland.
-
-| Protocol | Address | |
-|----------------|----------------------------------------------------|----------------|
-| DNS-over-HTTPS | `https://resolver-eu.lelux.fi/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://resolver-eu.lelux.fi/dns-query&name=resolver-eu.lelux.fi), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://resolver-eu.lelux.fi/dns-query&name=resolver-eu.lelux.fi) |
-| DNS-over-TLS | `tls://resolver-eu.lelux.fi` | [Add to AdGuard](adguard:add_dns_server?address=tls://resolver-eu.lelux.fi&name=resolver-eu.lelux.fi), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://resolver-eu.lelux.fi&name=resolver-eu.lelux.fi) |
-
 ### Marbled Fennec
 
 Marbled Fennec Networks is hosting DNS resolvers that are capable of resolving both OpenNIC and ICANN domains
@@ -1332,7 +1255,7 @@ Marbled Fennec Networks is hosting DNS resolvers that are capable of resolving b
 
 #### Standard
 
-Blocks ads, trackers, and malware
+Blocks ads, trackers, and malware.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
@@ -1341,7 +1264,7 @@ Blocks ads, trackers, and malware
 
 #### Kids
 
-Kids-friendly filter that also blocks ads, trackers, and malware
+Kid-friendly filter that also blocks ads, trackers, and malware.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
@@ -1354,12 +1277,12 @@ Kids-friendly filter that also blocks ads, trackers, and malware
 
 #### OSZX DNS
 
-This service ia a small ad blocking DNS hobby project with D-o-H, D-o-T & DNSCrypt v2 support.
+This service is a small ad blocking DNS hobby project with D-o-H, D-o-T & DNSCrypt v2 support.
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `51.38.83.141` | [Add to AdGuard](adguard:add_dns_server?address=51.38.83.141&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=51.38.83.141&name=) |
-| DNS, IPv6 | `2001:41d0:801:2000::d64` | [Add to AdGuard](adguard:add_dns_server?address=2001:41d0:801:2000::d64&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:41d0:801:2000::d64&name=) |
+| DNS, IPv4 | `51.38.83.141` | [Add to AdGuard](adguard:add_dns_server?address=51.38.83.141&name=OSZX%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=51.38.83.141&name=OSZX%20DNS) |
+| DNS, IPv6 | `2001:41d0:801:2000::d64` | [Add to AdGuard](adguard:add_dns_server?address=2001:41d0:801:2000::d64&name=OSZX%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:41d0:801:2000::d64&name=OSZX%20DNS) |
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.oszx.co` IP: `51.38.83.141:5353`| [Add to AdGuard](sdns://AQIAAAAAAAAAETUxLjM4LjgzLjE0MTo1MzUzIMwm9_oYw26P4JIVoDhJ_5kFDdNxX1ke4fEzL1V5bwEjFzIuZG5zY3J5cHQtY2VydC5vc3p4LmNv) |
 | DNSCrypt, IPv6 | Provider: `2.dnscrypt-cert.oszx.co` IP: `[2001:41d0:801:2000::d64]:5353`| [Add to AdGuard](sdns://AQIAAAAAAAAAHDIwMDE6NDFkMDo4MDE6MjAwMDo6ZDY0OjUzNTMgzCb3-hjDbo_gkhWgOEn_mQUN03FfWR7h8TMvVXlvASMXMi5kbnNjcnlwdC1jZXJ0Lm9zenguY28) |
 | DNS-over-HTTPS | `https://dns.oszx.co/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.oszx.co/dns-query&name=dns.oszx.co), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.oszx.co/dns-query&name=dns.oszx.co) |
@@ -1371,8 +1294,8 @@ These servers provide no ad blocking, keep no logs, and have DNSSEC enabled.
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `51.38.82.198` | [Add to AdGuard](adguard:add_dns_server?address=51.38.82.198&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=51.38.82.198&name=) |
-| DNS, IPv6 | `2001:41d0:801:2000::1b28` | [Add to AdGuard](adguard:add_dns_server?address=2001:41d0:801:2000::1b28&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:41d0:801:2000::1b28&name=) |
+| DNS, IPv4 | `51.38.82.198` | [Add to AdGuard](adguard:add_dns_server?address=51.38.82.198&name=PumpleX), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=51.38.82.198&name=PumpleX) |
+| DNS, IPv6 | `2001:41d0:801:2000::1b28` | [Add to AdGuard](adguard:add_dns_server?address=2001:41d0:801:2000::1b28&name=PumpleX), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2001:41d0:801:2000::1b28&name=PumpleX) |
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.pumplex.com` IP: `51.38.82.198:5353`| [Add to AdGuard](sdns://AQcAAAAAAAAAETUxLjM4LjgyLjE5ODo1MzUzIMg95SNgpDPLmaHlbZVbYh5tJRvnYuDWqZ4lUG-mD49eGzIuZG5zY3J5cHQtY2VydC5wdW1wbGV4LmNvbQ) |
 | DNSCrypt, IPv6 | Provider: `2.dnscrypt-cert.pumplex.com` IP: `[2001:41d0:801:2000::1b28]:5353`| [Add to AdGuard](sdns://AQcAAAAAAAAAHTIwMDE6NDFkMDo4MDE6MjAwMDo6MWIyODo1MzUzIMg95SNgpDPLmaHlbZVbYh5tJRvnYuDWqZ4lUG-mD49eGzIuZG5zY3J5cHQtY2VydC5wdW1wbGV4LmNvbQ) |
 | DNS-over-HTTPS | `https://dns.pumplex.com/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://dns.pumplex.com/dns-query&name=dns.pumplex.com), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://dns.pumplex.com/dns-query&name=dns.pumplex.com) |
@@ -1384,10 +1307,10 @@ These servers provide no ad blocking, keep no logs, and have DNSSEC enabled.
 
 #### Singapore DNS Server
 
-| Protocol | Address | Location |
-|----------------|-------------------------------------|---------------|
-| DNS, IPv4 | `174.138.21.128` | [Add to AdGuard](adguard:add_dns_server?address=174.138.21.128&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=174.138.21.128&name=) |
-| DNS, IPv6 | `2400:6180:0:d0::5f6e:4001` | [Add to AdGuard](adguard:add_dns_server?address=2400:6180:0:d0::5f6e:4001&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2400:6180:0:d0::5f6e:4001&name=) |
+| Protocol | Address | |
+|----------------|-------------------------------------|----------------|
+| DNS, IPv4 | `174.138.21.128` | [Add to AdGuard](adguard:add_dns_server?address=174.138.21.128&name=Privacy-First%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=174.138.21.128&name=Privacy-First%20DNS) |
+| DNS, IPv6 | `2400:6180:0:d0::5f6e:4001` | [Add to AdGuard](adguard:add_dns_server?address=2400:6180:0:d0::5f6e:4001&name=Privacy-First%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2400:6180:0:d0::5f6e:4001&name=Privacy-First%20DNS) |
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.dns.tiar.app` IP: `174.138.21.128`| [Add to AdGuard](sdns://AQMAAAAAAAAADjE3NC4xMzguMjEuMTI4IO-WgGbo2ZTwZdg-3dMa7u31bYZXRj5KykfN1_6Xw9T2HDIuZG5zY3J5cHQtY2VydC5kbnMudGlhci5hcHA) |
 | DNSCrypt, IPv6 | Provider: `2.dnscrypt-cert.dns.tiar.app` IP: `[2400:6180:0:d0::5f6e:4001]`| [Add to AdGuard](sdns://AQMAAAAAAAAAG1syNDAwOjYxODA6MDpkMDo6NWY2ZTo0MDAxXSDvloBm6NmU8GXYPt3TGu7t9W2GV0Y-SspHzdf-l8PU9hwyLmRuc2NyeXB0LWNlcnQuZG5zLnRpYXIuYXBw) |
 | DNS-over-HTTPS | `https://doh.tiarap.org/dns-query` (cached via third-party) | [Add to AdGuard](adguard:add_dns_server?address=https://doh.tiarap.org/dns-query&name=doh.tiarap.org), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://doh.tiarap.org/dns-query&name=doh.tiarap.org) |
@@ -1399,8 +1322,8 @@ These servers provide no ad blocking, keep no logs, and have DNSSEC enabled.
 
 | Protocol | Address | |
 |----------------|-------------------------------------|----------------|
-| DNS, IPv4 | `172.104.93.80` | [Add to AdGuard](adguard:add_dns_server?address=172.104.93.80&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=172.104.93.80&name=) |
-| DNS, IPv6 | `2400:8902::f03c:91ff:feda:c514` | [Add to AdGuard](adguard:add_dns_server?address=2400:8902::f03c:91ff:feda:c514&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2400:8902::f03c:91ff:feda:c514&name=) |
+| DNS, IPv4 | `172.104.93.80` | [Add to AdGuard](adguard:add_dns_server?address=172.104.93.80&name=Privacy-First%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=172.104.93.80&name=Privacy-First%20DNS) |
+| DNS, IPv6 | `2400:8902::f03c:91ff:feda:c514` | [Add to AdGuard](adguard:add_dns_server?address=2400:8902::f03c:91ff:feda:c514&name=Privacy-First%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=2400:8902::f03c:91ff:feda:c514&name=Privacy-First%20DNS) |
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.jp.tiar.app` IP: `172.104.93.80`| [Add to AdGuard](sdns://AQcAAAAAAAAAEjE3Mi4xMDQuOTMuODA6MTQ0MyAyuHY-8b9lNqHeahPAzW9IoXnjiLaZpTeNbVs8TN9UUxsyLmRuc2NyeXB0LWNlcnQuanAudGlhci5hcHA) |
 | DNSCrypt, IPv6 | Provider: `2.dnscrypt-cert.jp.tiar.app` IP: `[2400:8902::f03c:91ff:feda:c514]`| [Add to AdGuard](sdns://AQcAAAAAAAAAJVsyNDAwOjg5MDI6OmYwM2M6OTFmZjpmZWRhOmM1MTRdOjE0NDMgMrh2PvG_ZTah3moTwM1vSKF544i2maU3jW1bPEzfVFMbMi5kbnNjcnlwdC1jZXJ0LmpwLnRpYXIuYXBw) |
 | DNS-over-HTTPS | `https://jp.tiarap.org/dns-query` | [Add to AdGuard](adguard:add_dns_server?address=https://jp.tiarap.org/dns-query&name=jp.tiarap.org), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=https://jp.tiarap.org/dns-query&name=jp.tiarap.org) |
@@ -1415,7 +1338,7 @@ These servers provide no ad blocking, keep no logs, and have DNSSEC enabled.
 
 | Protocol | Address | |
 |----------------|----------------------------------------------------|----------------|
-| DNS, IPv4 | `45.76.113.31` | [Add to AdGuard](adguard:add_dns_server?address=45.76.113.31&name=), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=45.76.113.31&name=) |
+| DNS, IPv4 | `45.76.113.31` | [Add to AdGuard](adguard:add_dns_server?address=45.76.113.31&name=Seby%20DNS), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=45.76.113.31&name=Seby%20DNS) |
 | DNSCrypt, IPv4 | Provider: `2.dnscrypt-cert.dns.seby.io` IP: `45.76.113.31`| [Add to AdGuard](sdns://AQcAAAAAAAAADDQ1Ljc2LjExMy4zMSAIVGh4i6eKXqlF6o9Fg92cgD2WcDvKQJ7v_Wq4XrQsVhsyLmRuc2NyeXB0LWNlcnQuZG5zLnNlYnkuaW8) |
 | DNS-over-TLS | `tls://dot.seby.io` | [Add to AdGuard](adguard:add_dns_server?address=tls://dot.seby.io&name=tls://dot.seby.io), [Add to AdGuard VPN](adguardvpn:add_dns_server?address=tls://dot.seby.io&name=tls://dot.seby.io) |
 

--- a/docs/general/dns-providers.md
+++ b/docs/general/dns-providers.md
@@ -682,7 +682,7 @@ EDNS Client Subnet is a method that includes components of end-user IP address d
 It is designed with various optimizations, such as HTTP/3, caching, and more.
 It leverages machine learning to protect users from potential security threats while also optimizing itself over time.
 Some of its users can see how the DNS handles queries in real-time from its statistics page, but currently the stats page is temporarily disabled.
-Even if the stats page is temporarily disabled, the DNS itself still able to serve users' requests normally.
+Even if the stats page is temporarily disabled, the DNS itself still able to serve users’ requests normally.
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|


### PR DESCRIPTION
## Summary

This PR carries a comprehensive cleanup pass over the Known DNS Providers list (`docs/general/dns-providers.md`). It removes providers whose endpoints are no longer functional or have been abandoned, fixes broken deep links that cause "Add to AdGuard" actions to land on wrong servers, corrects grammar and spelling, standardizes the `name=` parameter across all deep links, normalizes non-standard protocol labels, and reorders providers to case-insensitive alphabetical order within each section.

> [!NOTE]
> I'm open to suggestions or requested changes on any of the changes in this PR — structural choices, provider removals, naming conventions, or anything else. If the AdGuard team has better ideas on how to handle something, happy to adjust.

---

## Changes

### 1. Removed 7 provider entries

These providers either no longer have resolvable DNS hostnames, have had unreachable encrypted endpoints confirmed through testing, or are abandoned projects:

| Removed | Reason |
|---------|--------|
| **CFIEC Public DNS** | `dns.cfiec.net` returns NXDOMAIN; no A/AAAA records exist. The parent domain `cfiec.net` resolves but the DNS subdomain is gone with no replacement hostname found. |
| **Fondation Restena DNS** | `kaitain.restena.lu` returns NXDOMAIN. The Restena Foundation website remains operational but the specific public resolver hostname has been retired with no alternative documented. |
| **Lelux DNS** | `resolver-eu.lelux.fi` returns NXDOMAIN. The parent domain `lelux.fi` resolves but the resolver page returns 404. |
| **Arapurayil** | `dns.arapurayil.com` returns SERVFAIL; the parent domain `arapurayil.com` itself is unresolvable. |
| **Quadrant Security** | `doh.qis.io` (157.230.188.174) resolves but TCP port 443 consistently times out. The parent company (`quadrantsec.com`) remains active but the public DNS resolver endpoint appears to have been retired. |
| **Rabbit DNS** | `dns.rabbitdns.org` resolves (behind Cloudflare) but consistently returns HTTP 522 (upstream connection timeout). The website and GitHub organization remain online, but the DNS backend has been non-functional since at least early 2023 (last repo push to rabbit-dns was Feb 2023). |
| **dnswarden** | `dns.dnswarden.com` resolves to 149.248.217.117 but TLS handshake is consistently reset by peer. The project website (`dnswarden.com`) is operational and the project is actively maintained. The DNS service endpoint failure may be environment-specific or a transient issue. Removal recommended cautiously — the entry can be restored if the endpoint confirms operational from other networks. |

### 2. Flagged 4 providers as operationally impaired

Inline notes were added where the service is partially functional:

- **Caliph DNS** — website returns HTTP 502; DNS applies SafeSearch enforcement on Google queries and blocks certain domains (e.g. Reddit returns `internetpositif.id`)
- **Xstl DNS** — encrypted hostnames (`dns.seia.io`, `secondary.dns.seia.io`) currently do not resolve; plain DNS IPs (`116.121.57.111`, `140.238.14.191`) are confirmed operational
- **BlackMagicc DNS** — DoH and DoQ endpoints (`rx.techomespace.com`) connection-time out; plain DNS (IPv4/IPv6) retained
- **JupitrDNS** — TLS certificate is signed by a Let's Encrypt staging CA and will be rejected by standard clients

### 3. Fixed 12 broken deep links

| Fix | Detail |
|-----|--------|
| ControlD Non-filtering IPv4 | Deep link IP `76.76.2.1` corrected to `76.76.2.0` to match the listed address |
| ControlD Non-filtering IPv6 | Protocol label `IPv6` corrected to `DNS, IPv6` (was missing the `DNS,` prefix) |
| ControlD Non-filtering DoT | `p0.freedns.controld.com` given `tls://` prefix in address and deep link |
| ControlD Block malware+ads+social | Double bracket `[[Add to AdGuard]` fixed |
| Cisco OpenDNS Sandbox IPv4 | Deep link IP `208.67.220.2` corrected to `208.67.222.2` |
| Quad9 Unsecured IPv4 VPN link | IP `9.9.9.100` corrected to `149.112.112.10` |
| DNS4EU Unfiltered | DoH and DoT deep links used `child-noads.joindns4.eu` instead of `unfiltered.joindns4.eu` (copy-paste error) |
| BebasDNS OISD & Hagezi DoH links | Deep links pointed to `internetsehat.bebasid.com/adblock` instead of the correct variant paths |
| DNS for Family DoH link | Double `https://` prefix in deep link (`https://https://...`) corrected |
| BebasDNS Default DoT link | Missing `tls://` prefix in deep link |
| Caliph DNS DoT link | Missing `tls://` prefix in deep link |
| BebasDNS all sub-variants DoT links (6) | All missing `tls://` prefixes in deep links fixed |

### 4. Grammar and spelling (18 corrections)

Applied throughout provider descriptions — missing articles, subject-verb agreement, typos (`ia` to `is`, `IPV4` to `IPv4`, `contents` to `content`, `proper` to `properly`), missing punctuation, and awkward phrasing.

### 5. Structural standardization

- **`name=` parameters**: Every `adguard:add_dns_server` deep link now carries a non-empty `name=` value populated with the URL-encoded provider name rather than being empty or using a raw IP address. This affects approximately 60 plain DNS (IPv4/IPv6) rows across all providers.
- **DNSGuard protocol labels**: Non-standard `DNS 1, IPv4` / `DNS 2, IPv4` labels replaced with conventional `DNS, IPv4` / `DNS, IPv6` with merged address rows.
- **OpenBLD.net**: Added `adguard:add_dns_server` deep links alongside existing `sdns://` stamps.
- **Privacy-First DNS Singapore**: Table column header `| Location |` replaced with the standard empty-column format; action links moved to the correct column.
- **Caliph DNS table header**: `| Type | Address |` changed to `| Protocol | Address |`.

### 6. Sorting

Providers are now in case-insensitive alphabetical order within each of the three sections:

- **Public anycast resolvers**: AdGuard DNS (retained as first entry) > 360 Secure DNS > Ali DNS > BebasDNS > Caliph DNS > ...
- **Regional resolvers**: 114DNS > Applied Privacy DNS > ...
- **Small personal resolvers**: 18Bit DNS > AhaDNS > ... > DNS Forge > DNSGuard > ... > fvz DNS > HaGeZi DNS > ...

This moves 360 Secure DNS from near the end of Public anycast to position 2, Caliph DNS after BebasDNS, 114DNS to first in Regional resolvers, v.recipes DNS before Verisign, DNS Forge before DNSGuard, and fvz DNS before HaGeZi DNS.

---

## Potential Conflicts with Open PRs

This PR touches many lines across `dns-providers.md` and will conflict with several other open PRs. Below is a list of affected PRs and instructions for resolving each conflict.

### PR https://github.com/AdguardTeam/KnowledgeBaseDNS/pull/417 — Fix unfiltered joindns4.eu entries
**Head**: `ebaschiera:patch-1` | **Scope**: 2 lines — DNS4EU Unfiltered DoH and DoT deep link URLs

Corrects the same `child-noads.joindns4.eu` → `unfiltered.joindns4.eu` URL fix in the DNS4EU Unfiltered section that this PR also applies. Our fix additionally updates the deep link `name=` parameters and adds AdGuard VPN links. Resolution: accept this PR's version. If merged first, this PR carries their change plus the additional deep-link fixes.

### PR https://github.com/AdguardTeam/KnowledgeBaseDNS/pull/379 — Fix DNS4EU unfiltered addresses
**Head**: `Pyker:patch-1` | **Scope**: 3 lines — DNS4EU Unfiltered IPv6 secondary address, DoH URL, DoT URL

Fixes the IPv6 duplicate address (`86.54.11.100` → `86.54.11.200` for the second IP) plus the same DoH/DoT `child-noads` → `unfiltered` URL fix. Our PR fixes the DoH/DoT URLs but did NOT fix the IPv6 secondary IP. Resolution: merge should combine both — take the IPv6 address fix from PR #379 and the deep-link `name=` + AdGuard VPN link additions from this PR. If merged first, this PR should add the IPv6 address fix.

### PR https://github.com/AdguardTeam/KnowledgeBaseDNS/pull/344 — Add `tls://` prefix to some URLs
**Head**: `3x:patch-1` | **Scope**: 5 lines — ControlD DoT address column, NIC Chile DoT address column, OARC DoT address column, Wikimedia DNS DoT address column, dnswarden DoT address column

Adds `tls://` prefix to the Address column (not deep links) for 5 entries. Overlap with this PR: ControlD Non-filtering DoT (we added `tls://` to both the address column and the deep link) and dnswarden (we removed the entry entirely, superseding their change). The other 3 entries (NIC Chile, OARC, Wikimedia DNS) are not touched by this PR. Resolution: keep the non-conflicting changes from both PRs. For ControlD, keep this PR's version (which fixes both address and deep link). For dnswarden, the removal supersedes.

### PR https://github.com/AdguardTeam/KnowledgeBaseDNS/pull/389 — Add DoH support for Quad101 and update links
**Head**: `HJ-zhtw:patch-2` | **Scope**: 4 additions, 3 deletions — Quad101 entry: new DoH row, `name=` updated from empty to `Quad101` on all rows

Adds a DoH row (`https://dns.twnic.tw/dns-query`) and populates `name=Quad101` on all deep links. Our PR also sets `name=Quad101` via the blanket `name=` standardization. Overlap only on the existing rows' `name=` values — which are identical in both PRs. Resolution: accept the combined result. If merged first, this PR's `name=` changes for Quad101 are already satisfied.

### PR https://github.com/AdguardTeam/KnowledgeBaseDNS/pull/386 — Revise ASTRACAT DNS details
**Head**: `ASTRACAT2022:patch-6` | **Scope**: 8 additions, 10 deletions — replaces ASTRACAT entry entirely and moves it

Replaces the old ASTRACAT DNS entry (Small personal resolvers, `85.209.2.112`, `astracat.vercel.app`) with a new one (Regional resolvers after Yandex DNS, `dns.astracat.ru`, new description). This PR touches the old ASTRACAT entry through sorting (it was reordered) and `name=` standardization. Resolution: if PR #386 is merged first, our sorting and name changes to the old entry are moot and the new entry should be placed in its correct alphabetical position within Regional resolvers. If this PR is merged first, PR #386 would need to apply its changes on top of the updated file.

### PR https://github.com/AdguardTeam/KnowledgeBaseDNS/pull/335 — Add SZ DNS
**Head**: `szhu25:patch-1` | **Scope**: 10 additions — appends SZ DNS at the end of the file (after 18Bit DNS in Small personal resolvers)

Adds SZ DNS at the end of the document rather than in its correct alphabetical position (SZ belongs in the Regional resolvers section between SWITCH DNS and UK DNS Privacy Project). Resolution: if merged first, our sorting pass would need to move SZ DNS from the Small personal section to the Regional section between SWITCH DNS and UK DNS Privacy Project. If this PR is merged first, PR #335 would need to rebase and insert SZ DNS in the Regional resolvers section at the correct alphabetical position rather than appending at the end of the file.

---

## Files Changed

```
docs/general/dns-providers.md | 545 changes (234 insertions, 311 deletions)
```

Signed-off-by: Galih Tama <galpt@v.recipes>