### PR TITLE
adguard-home: clarify manual-update architecture

### DIFF
--- a/docs/adguard-home/faq.md
+++ b/docs/adguard-home/faq.md
@@ -361,6 +361,15 @@ If the button isn’t displayed or an automatic update has failed, you can updat
 
 ### Unix (Linux, macOS, BSD) {#manual-update-unix}
 
+:::important
+
+The commands below use packages for AMD64 CPUs.  Run `uname -m` before
+downloading: use `amd64` for `x86_64`, and `arm64` for `aarch64` or `arm64`.
+Replace every `amd64` in the package name and URL with that value.  For other
+results, choose the matching package from the [supported platforms page](/adguard-home/platforms#packaged-releases).
+
+:::
+
 1. Download the new AdGuard Home package from the [releases page][releases]. If you want to perform this step from the command line, type:
 
    ```sh


### PR DESCRIPTION
## Summary

- warn that the manual-update commands use AMD64 packages
- map `uname -m` values to the AdGuard Home `amd64` and `arm64` archive labels
- direct other architectures to the supported-platform package matrix

## Why

AdguardTeam/AdGuardHome#4985 reports 64-bit ARM users following the manual-update example and ending up with a binary for the wrong CPU architecture.  The FAQ identifies AMD64 as the example, but it does not tell `aarch64` or `arm64` users which archive label to use or that every architecture token in the file name and URL must be changed consistently.

Updates AdguardTeam/AdGuardHome#4985.

## Validation

- `CI=true npx --yes pnpm@9.15.9 lint:md`
- `CI=true NODE_OPTIONS=--no-experimental-webstorage npx --yes pnpm@9.15.9 build --locale en`
- `git diff --check`
- verified both official Linux AMD64 and ARM64 archive URLs return HTTP 200
- inspected the generated FAQ HTML to confirm the admonition and supported-platform anchor render correctly