### PR TITLE
adguard-home: avoid installing apache for password reset

### DIFF
--- a/docs/adguard-home/configuration.md
+++ b/docs/adguard-home/configuration.md
@@ -838,12 +838,12 @@ Removing an entry from settings file will reset it to the default value. Deletin
 
 Please follow these steps to create a new password for your user account:
 
-1. Install `htpasswd`, which is a part of *Apache2 Web Server:*
+1. Install `htpasswd`. On Linux, install the utility package instead of the Apache2 Web Server:
 
      - Ubuntu:
 
         ```sh
-        sudo apt-get install apache2
+        sudo apt-get install apache2-utils
         ```
 
      - Fedora:


### PR DESCRIPTION
## Summary

- clarify that only the `htpasswd` utility is needed
- install Ubuntu's `apache2-utils` package instead of the full `apache2` server
  package

Fixes AdguardTeam/AdGuardHome#6865.

## Testing

- `node_modules/.bin/markdownlint .`
- `URL=https://kb-dns.pages.dev BASE_URL=/ node_modules/.bin/docusaurus build`
